### PR TITLE
Implement outcome setup and document manifests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,3 +56,12 @@ Rscript -e "devtools::load\_all(); run\_phenome\_mr(exposure\_snps = …, sex = 
 
 
 
+
+## Packaged data files
+
+The package ships with several `.rda` files (located in `data/`) used by `Outcome_setup()`:
+
+- `bothsex_ARD.rda`, `female_ARD.rda`, `male_ARD.rda` – ARD phenotype tables for both sexes, females, and males.
+- `neale_female_manifest.rda`, `neale_male_manifest.rda` – Neale sex-specific phenotype manifests containing case and control counts.
+- `neale_file_manifest.rda` – Neale download information for each GWAS.
+- `panukb_pheno_manifest.rda` – Pan-UKB phenotype manifest with metadata and download links.

--- a/README.md
+++ b/README.md
@@ -365,6 +365,19 @@ We also mark **Status** for the current v0:
   * **Pan-UKB:** remote tabix URL + manifested column map
   * **Neale:** local `.tsv.bgz` + `.tbi` in `neale_gwas_dir`
 
+### Packaged manifests
+
+The repository bundles several `.rda` files (in `data/`) consumed by
+`Outcome_setup()`:
+
+- `bothsex_ARD.rda`, `female_ARD.rda`, `male_ARD.rda` – ARD phenotype tables
+  for both sexes, females, and males.
+- `neale_female_manifest.rda`, `neale_male_manifest.rda` – Neale sex-specific
+  phenotype manifests with case and control counts.
+- `neale_file_manifest.rda` – Neale download information for each GWAS.
+- `panukb_pheno_manifest.rda` – Pan-UKB phenotype manifest with metadata and
+  download links.
+
 ---
 
 ## QC checklist (8)


### PR DESCRIPTION
## Summary
- Add `Outcome_setup` to build MR_df by mapping ARD phenotypes to Pan-UKB or Neale manifests
- Document bundled `.rda` manifest and ARD files in AGENTS and README

## Testing
- `R CMD build .`
- `R CMD check ardmr_0.0.0.9000.tar.gz --no-manual` *(fails: Packages required but not available: 'data.table', 'dplyr', 'ggplot2', 'ggrepel', 'logger', 'purrr', 'stringr', 'tibble', 'TwoSampleMR')*


------
https://chatgpt.com/codex/tasks/task_e_68b3a7d82464832c82fe0487f8da9d82