### PR TITLE
Add dependency installation script and update docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,12 @@ This file guides AI agents (like OpenAI Codex) working on the \*\*ARDMR\*\* pack
 
 \## Build \& Test
 
+Before testing or development, install package dependencies:
+
+```bash
+Rscript scripts/install_deps.R
+```
+
 
 
 \*\*To run the full pipeline end-to-end (on real or fixture data):\*\*

--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ Automates outcome resolution (ICD-10 ↔ GBD), SNP row extraction from Pan-UKB /
 
 ## Install
 
+Before developing or running tests, install package dependencies:
+
+```bash
+Rscript scripts/install_deps.R
+```
+
 ```r
 # requires: R >= 4.1, tabix in PATH, bgzip (.tbi) support
 # and CRAN/BioC deps: data.table, dplyr, ggplot2, TwoSampleMR, etc.

--- a/scripts/install_deps.R
+++ b/scripts/install_deps.R
@@ -1,0 +1,4 @@
+if (!requireNamespace("remotes", quietly = TRUE)) {
+  install.packages("remotes")
+}
+remotes::install_deps()


### PR DESCRIPTION
## Summary
- add `scripts/install_deps.R` for installing package dependencies via `remotes::install_deps()`
- document running `Rscript scripts/install_deps.R` before development or testing in README and AGENTS

## Testing
- `Rscript scripts/install_deps.R` *(fails: remotes package not available from CRAN)*
- `Rscript -e 'devtools::test()'` *(fails: there is no package called 'devtools')*

------
https://chatgpt.com/codex/tasks/task_e_68b45af17fe4832c9dacb12e8305f185