### PR TITLE
Refactor dependency installation script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@
 
 This file guides AI agents (like OpenAI Codex) working on the \*\*ARDMR\*\* package. Think of it as a README for AI, not humans — follow it precisely to produce consistent, high-quality code.
 
+- **Script location:** place all helper scripts in `R/`; the `scripts/` directory is deprecated.
 
 
 ---
@@ -49,7 +50,7 @@ This file guides AI agents (like OpenAI Codex) working on the \*\*ARDMR\*\* pack
 Before testing or development, install package dependencies:
 
 ```bash
-Rscript scripts/install_deps.R
+Rscript -e "source('R/install_deps.R'); install_deps()"
 ```
 
 

--- a/R/install_deps.R
+++ b/R/install_deps.R
@@ -1,0 +1,13 @@
+#' Install package dependencies
+#'
+#' Ensures the required packages for this project are installed.
+#' If the `remotes` package is missing, it will be installed first.
+#'
+#' @keywords internal
+install_deps <- function() {
+  if (!requireNamespace("remotes", quietly = TRUE)) {
+    install.packages("remotes")
+  }
+  remotes::install_deps()
+  invisible(NULL)
+}

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Automates outcome resolution (ICD-10 ↔ GBD), SNP row extraction from Pan-UKB /
 Before developing or running tests, install package dependencies:
 
 ```bash
-Rscript scripts/install_deps.R
+Rscript -e "source('R/install_deps.R'); install_deps()"
 ```
 
 ```r

--- a/scripts/install_deps.R
+++ b/scripts/install_deps.R
@@ -1,4 +1,0 @@
-if (!requireNamespace("remotes", quietly = TRUE)) {
-  install.packages("remotes")
-}
-remotes::install_deps()


### PR DESCRIPTION
## Summary
- Move install_deps script into R/ as an internal helper function
- Update documentation to call the new install_deps helper and clarify script location

## Testing
- ⚠️ `Rscript -e "source('R/install_deps.R'); install_deps()"` (Rscript missing)
- ⚠️ `apt-get install -y r-base` (attempted to install R but process did not complete)


------
https://chatgpt.com/codex/tasks/task_e_68b45c2b48c0832c97e4bf4c77be7658