### PR TITLE
Log ARD/non-ARD phenotype counts

### DIFF
--- a/R/outcome_setup.R
+++ b/R/outcome_setup.R
@@ -32,8 +32,10 @@ Outcome_setup <- function(sex, ancestry) {
     "female" = get_pkg_obj("female_all")
   )
 
+  n_ard <- sum(pheno_df$ARD_selected)
+  n_non <- nrow(pheno_df) - n_ard
   logger::log_info(
-    "ARD+non-ARD phenotypes| {nrow(pheno_df)} rows; {dplyr::n_distinct(pheno_df$ICD10_explo)} unique ICD10; {dplyr::n_distinct(pheno_df$cause_level_3)} unique causes"
+    "ARD+non-ARD phenotypes| {nrow(pheno_df)} rows ({n_ard} ARD, {n_non} non-ARD); {dplyr::n_distinct(pheno_df$ICD10_explo)} unique ICD10; {dplyr::n_distinct(pheno_df$cause_level_3)} unique causes"
   )
 
   # ---- load manifest -------------------------------------------------------

--- a/R/run_phenome_mr.R
+++ b/R/run_phenome_mr.R
@@ -92,7 +92,9 @@ run_phenome_mr <- function(
   logger::log_info("1) Outcome setup…")
   MR_df <- Outcome_setup(sex = cfg$sex, ancestry = cfg$ancestry)
   metrics$outcomes <- nrow(MR_df)
-  logger::log_info("Outcome setup: {metrics$outcomes} ARDs loaded")
+  metrics$n_ard <- sum(MR_df$ARD_selected)
+  metrics$n_non <- metrics$outcomes - metrics$n_ard
+  logger::log_info("Outcome setup: {metrics$outcomes} phenotypes loaded ({metrics$n_ard} ARD, {metrics$n_non} non-ARD)")
 
   logger::log_info("1.1) Variant manifest downloading…")
   Variant_manifest_downloader(catalog = cfg$catalog, cache_dir = cfg$cache_dir, overwrite = FALSE)
@@ -145,8 +147,14 @@ run_phenome_mr <- function(
   }
 
   summary_tbl <- tibble::tibble(
-    stage = c("outcomes","exposure_in","exposure_mapped","outcome_snps","results"),
-    count = c(metrics$outcomes, metrics$exposure_in, metrics$exposure_mapped, metrics$outcome_snps, metrics$results)
+    stage = c(
+      "outcomes","outcomes_ARD","outcomes_nonARD",
+      "exposure_in","exposure_mapped","outcome_snps","results"
+    ),
+    count = c(
+      metrics$outcomes, metrics$n_ard, metrics$n_non,
+      metrics$exposure_in, metrics$exposure_mapped, metrics$outcome_snps, metrics$results
+    )
   )
   logger::log_info(
     "Summary counts:\n{paste(capture.output(print(summary_tbl)), collapse = '\n')}"


### PR DESCRIPTION
## Summary
- log ARD vs non-ARD phenotype counts during outcome setup
- propagate ARD/non-ARD counts into run_phenome_mr metrics and summary table

## Testing
- `Rscript -e "source('R/install_deps.R'); install_deps()"` *(fails: package `Rhtslib` 2.2.0 < 3.3.1 for `Rsamtools`)*
- `Rscript -e "devtools::test()"` *(fails: no package called `devtools`)*

------
https://chatgpt.com/codex/tasks/task_e_68c337e3a87c832cb76f1d377cfa9050