### PR TITLE
Include effect allele in Pan-UKB SNP join

### DIFF
--- a/R/panukb_snp_grabber.R
+++ b/R/panukb_snp_grabber.R
@@ -44,7 +44,7 @@ panukb_snp_grabber <- function(exposure_snps, MR_df, ancestry, cache_dir = ardmr
   }
 
   exp_lu <- tibble::as_tibble(exposure_snps) |>
-    dplyr::select(rsid, panukb_chrom, panukb_pos) |>
+    dplyr::select(rsid, panukb_chrom, panukb_pos, effect_allele) |>
     dplyr::distinct()
 
   # ---- enforce link columns in MR_df ----
@@ -233,7 +233,7 @@ panukb_snp_grabber <- function(exposure_snps, MR_df, ancestry, cache_dir = ardmr
     panukb_std <- dplyr::inner_join(
       panukb_std,
       exp_lu,
-      by = c("chr" = "panukb_chrom", "pos" = "panukb_pos")
+      by = c("chr" = "panukb_chrom", "pos" = "panukb_pos", "effect_allele")
     )
 
     if (!"rsid" %in% names(panukb_std)) {
@@ -246,6 +246,7 @@ panukb_snp_grabber <- function(exposure_snps, MR_df, ancestry, cache_dir = ardmr
 
     panukb_std <- dplyr::relocate(panukb_std, rsid, .before = 1)
     names(panukb_std)[names(panukb_std) == "rsid"] <- "SNP"
+    panukb_std <- dplyr::distinct(panukb_std, SNP, effect_allele, .keep_all = TRUE)
     panukb_std$chrpos <- paste0(panukb_std$chr, ":", panukb_std$pos)
     panukb_std$Phenotype <- outcome_label
 


### PR DESCRIPTION
## Summary
- Track effect allele in exposure lookup table
- Join Pan-UKB data on chromosome, position, and effect allele
- Deduplicate overlapping SNP-allele combinations after join

## Testing
- `Rscript -e "source('R/install_deps.R'); install_deps()"` *(failed: missing Bioconductor dependencies)*
- `Rscript -e "devtools::test()"` *(failed: there is no package called 'devtools')*
- `Rscript -e "devtools::load_all(); exp <- readr::read_csv('inst/extdata/TEST_exposure_snps.csv'); run_phenome_mr(exposure_snps = exp, ancestry = 'EUR', sex = 'both', cache_dir = tempdir(), verbose = FALSE)"` *(failed: there is no package called 'devtools')*


------
https://chatgpt.com/codex/tasks/task_e_68c490e09f54832c8579457996398384