### PR TITLE
Ensure uppercase effect alleles for Pan-UKB lookups

### DIFF
--- a/R/panukb_snp_grabber.R
+++ b/R/panukb_snp_grabber.R
@@ -47,6 +47,19 @@ panukb_snp_grabber <- function(exposure_snps, MR_df, ancestry, cache_dir = ardmr
          "\nDid you run exposure_snp_mapper() with sex='both'?", call. = FALSE)
   }
 
+  exposure_snps <- exposure_snps |>
+    dplyr::mutate(effect_allele.exposure = toupper(.data$effect_allele.exposure))
+  bad_alleles <- unique(exposure_snps$effect_allele.exposure[
+    !exposure_snps$effect_allele.exposure %in% c("A", "C", "G", "T")
+  ])
+  if (length(bad_alleles)) {
+    stop(
+      "effect_allele.exposure contains non-ACGT values: ",
+      paste(bad_alleles, collapse = ", "),
+      call. = FALSE
+    )
+  }
+
   exp_lu <- tibble::as_tibble(exposure_snps) |>
     dplyr::select(rsid, panukb_chrom, panukb_pos, effect_allele.exposure) |>
     dplyr::distinct()


### PR DESCRIPTION
## Summary
- Uppercase `effect_allele.exposure` prior to lookup in `panukb_snp_grabber`
- Validate exposure alleles to contain only A/C/G/T and abort otherwise

## Testing
- `Rscript -e "source('R/install_deps.R'); install_deps()"` *(failed: installation errors for multiple dependencies)*
- `Rscript -e "devtools::test()"` *(failed: there is no package called 'devtools')*

------
https://chatgpt.com/codex/tasks/task_e_68c49a2ee80c832c9a4bd1ec2b8ade21