### PR TITLE
Use precomputed log10 p-values in plots

### DIFF
--- a/R/plots.R
+++ b/R/plots.R
@@ -63,7 +63,11 @@ manhattan_plot <- function(results_df,
 
   # Compute -log10(p)
   df <- dplyr::filter(df, !is.na(.data$results_p_ivw))
-  df$logp <- -log10(pmax(df$results_p_ivw, .Machine$double.xmin))
+  df$logp <- dplyr::if_else(
+    !is.na(df$results_log10p_ivw),
+    -df$results_log10p_ivw,
+    -log10(pmax(df$results_p_ivw, .Machine$double.xmin))
+  )
   if (!nrow(df)) return(ggplot2::ggplot() + ggplot2::labs(title = "Manhattan (no finite p-values)"))
 
   # =========== GROUPING & X POSITIONS (L1→L2) ===========
@@ -180,7 +184,11 @@ volcano_plot <- function(results_df,
 
   # computed axes
   df$z_ivw   <- df$results_beta_ivw / df$results_se_ivw
-  df$logp    <- -log10(pmax(df$results_p_ivw, .Machine$double.xmin))
+  df$logp    <- dplyr::if_else(
+    !is.na(df$results_log10p_ivw),
+    -df$results_log10p_ivw,
+    -log10(pmax(df$results_p_ivw, .Machine$double.xmin))
+  )
   if (!"results_qc_pass" %in% names(df)) df$results_qc_pass <- TRUE
   if (!"results_nsnp_after" %in% names(df)) df$results_nsnp_after <- NA_integer_
 


### PR DESCRIPTION
## Summary
- Avoid p-value truncation by using `results_log10p_ivw` when available in plotting functions
- Recomputed logp for both Manhattan and volcano plots

## Testing
- `Rscript -e "devtools::test()"` *(fails: there is no package called 'devtools')*
- `Rscript - <<'EOF'
source('R/plots.R')
# dataset with extremely small p-values and required columns
library(tibble)
example_df <- tibble(
  ARD_selected = TRUE,
  results_qc_pass = TRUE,
  results_p_ivw = 0,
  results_log10p_ivw = -500,
  results_beta_ivw = 1,
  results_se_ivw = 0.1,
  results_outcome = "outcome1",
  cause_level_1 = "L1",
  cause_level_2 = "L2",
  results_Q_p_ivw = NA_real_,
  results_I2_ivw = NA_real_,
  results_egger_intercept_p = NA_real_
)
# Run plots and output max logp values
mplot <- manhattan_plot(example_df, verbose = FALSE)
vplot <- volcano_plot(example_df)
cat('Manhattan max logp:', max(mplot$data$logp), '\n')
cat('Volcano max logp:', max(vplot$data$logp), '\n')
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68c4a8da5edc832ca7e904a3b0e39f24