### PR TITLE
Add confidence intervals to beta contrast global

### DIFF
--- a/R/enrichment_business_logic.R
+++ b/R/enrichment_business_logic.R
@@ -562,6 +562,7 @@ beta_contrast_global_ARD <- function(
                           n_in=sum(ard), n_out=sum(!ard),
                           beta_in=NA_real_, beta_out=NA_real_,
                           delta_beta=NA_real_, se_delta=NA_real_,
+                          ci_low=NA_real_, ci_high=NA_real_,
                           z=NA_real_, p=NA_real_, q=NA_real_, sig=NA))
   }
 
@@ -570,6 +571,8 @@ beta_contrast_global_ARD <- function(
   var_in   <- 1/sum(w[ard]); var_out <- 1/sum(w[!ard])
   se_delta <- sqrt(var_in + var_out)
   delta    <- beta_in - beta_out
+  ci_low   <- delta - 1.96 * se_delta
+  ci_high  <- delta + 1.96 * se_delta
   z        <- delta/se_delta
   p        <- 2*stats::pnorm(-abs(z))
   q        <- if (Multiple_testing_correction=="BH") p else p # single test => same
@@ -577,6 +580,7 @@ beta_contrast_global_ARD <- function(
                  n_in=sum(ard), n_out=sum(!ard),
                  beta_in=beta_in, beta_out=beta_out,
                  delta_beta=delta, se_delta=se_delta,
+                 ci_low=ci_low, ci_high=ci_high,
                  z=z, p=p, q=q, sig=(p < alpha))
 }
 

--- a/tests/testthat/test_enrichment_business_logic.R
+++ b/tests/testthat/test_enrichment_business_logic.R
@@ -1,0 +1,37 @@
+test_that("beta_contrast_global_ARD returns confidence intervals", {
+  df <- tibble::tibble(
+    results_beta_ivw = c(0.2, 0.15, -0.05, 0.0),
+    results_se_ivw = c(0.1, 0.12, 0.2, 0.18),
+    ARD_selected = c(TRUE, TRUE, FALSE, FALSE)
+  )
+
+  res <- ardmr:::beta_contrast_global_ARD(
+    results_df = df,
+    use_qc_pass = FALSE,
+    min_nsnp = NULL
+  )
+
+  expect_true(all(c("ci_low", "ci_high") %in% names(res)))
+  expect_type(res$ci_low, "double")
+  expect_type(res$ci_high, "double")
+  expect_equal(res$ci_low, res$delta_beta - 1.96 * res$se_delta)
+  expect_equal(res$ci_high, res$delta_beta + 1.96 * res$se_delta)
+})
+
+test_that("beta_contrast_global_ARD NA guard returns CI columns", {
+  df_all_ard <- tibble::tibble(
+    results_beta_ivw = c(0.2, 0.15),
+    results_se_ivw = c(0.1, 0.12),
+    ARD_selected = c(TRUE, TRUE)
+  )
+
+  res_na <- ardmr:::beta_contrast_global_ARD(
+    results_df = df_all_ard,
+    use_qc_pass = FALSE,
+    min_nsnp = NULL
+  )
+
+  expect_true(all(c("ci_low", "ci_high") %in% names(res_na)))
+  expect_true(all(is.na(res_na$ci_low)))
+  expect_true(all(is.na(res_na$ci_high)))
+})


### PR DESCRIPTION
## Summary
- add `ci_low` and `ci_high` to `beta_contrast_global_ARD()` outputs, including the NA guard branch
- compute Wald-style confidence intervals once `se_delta` is available
- cover the helper with tests that assert the CI columns exist and are numeric

## Testing
- not run (Rscript not available in execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68cabfd7b0dc832cae52a8b30a3ac794