### PR TITLE
Save plot data alongside generated figures

### DIFF
--- a/R/mr_business_logic.R
+++ b/R/mr_business_logic.R
@@ -53,6 +53,10 @@ mr_business_logic <- function(
   }
 
   .save_pub_plot <- function(plot, basepath, w_mm = 89, h_mm = 80, dpi = 500) {
+    dir_path <- dirname(basepath)
+    if (!dir.exists(dir_path)) {
+      dir.create(dir_path, recursive = TRUE, showWarnings = FALSE)
+    }
     # High-res PNG for quick viewing
     ggplot2::ggsave(paste0(basepath, ".png"), plot,
                     width = w_mm, height = h_mm, units = "mm",
@@ -61,6 +65,7 @@ mr_business_logic <- function(
     ggplot2::ggsave(paste0(basepath, ".pdf"), plot,
                     width = w_mm, height = h_mm, units = "mm",
                     device = cairo_pdf)
+    .ardmr_write_plot_data(plot, dir_path = dir_path, base_name = basename(basepath))
   }
 
 

--- a/R/plot_data_helpers.R
+++ b/R/plot_data_helpers.R
@@ -1,0 +1,142 @@
+# Internal helpers for attaching and exporting plot data frames
+
+#' @keywords internal
+.ardmr_sanitize_component <- function(x) {
+  x <- as.character(x)
+  x[is.na(x) | !nzchar(x)] <- "component"
+  x <- gsub("[^A-Za-z0-9._-]+", "_", x)
+  x <- gsub("_+", "_", x)
+  x <- sub("^_+", "", x)
+  x <- sub("_+$", "", x)
+  x <- ifelse(!nzchar(x), "component", x)
+  x
+}
+
+#' @keywords internal
+.ardmr_coerce_data_list <- function(x, default_prefix = "data") {
+  out <- list()
+  counter <- 1L
+
+  add_item <- function(item, nm = NULL) {
+    if (is.null(item)) return()
+
+    if (is.data.frame(item)) {
+      name_use <- nm
+      if (is.null(name_use) || !nzchar(name_use)) {
+        name_use <- sprintf("%s%d", default_prefix, counter)
+        counter <<- counter + 1L
+      }
+      out[[name_use]] <<- tibble::as_tibble(item)
+      return()
+    }
+
+    if (is.list(item)) {
+      nms <- names(item)
+      if (length(item) == 0) return()
+      for (i in seq_along(item)) {
+        nm_i <- nms[i]
+        if (!is.null(nm) && nzchar(nm)) {
+          if (is.null(nm_i) || !nzchar(nm_i)) {
+            nm_i <- nm
+          } else {
+            nm_i <- paste(nm, nm_i, sep = "__")
+          }
+        }
+        add_item(item[[i]], nm_i)
+      }
+      return()
+    }
+  }
+
+  if (is.list(x) && !is.data.frame(x)) {
+    nms <- names(x)
+    if (length(x) == 0) return(out)
+    for (i in seq_along(x)) {
+      nm_i <- nms[i]
+      add_item(x[[i]], nm_i)
+    }
+  } else {
+    add_item(x, NULL)
+  }
+
+  out
+}
+
+#' @keywords internal
+.ardmr_attach_plot_data <- function(plot, ...) {
+  data_list <- list(...)
+  if (length(data_list) == 1L && is.list(data_list[[1]]) &&
+      (is.null(names(data_list)) || !nzchar(names(data_list)[1]))) {
+    data_list <- data_list[[1]]
+  }
+  data_list <- .ardmr_coerce_data_list(data_list)
+  attr(plot, "ardmr_plot_data") <- data_list
+  plot
+}
+
+#' @keywords internal
+.ardmr_collect_plot_data <- function(plot, fallback = NULL) {
+  data_list <- attr(plot, "ardmr_plot_data", exact = TRUE)
+  data_list <- .ardmr_coerce_data_list(data_list)
+  if (length(data_list)) return(data_list)
+
+  fallback_list <- .ardmr_coerce_data_list(fallback)
+  if (length(fallback_list)) return(fallback_list)
+
+  if (is.data.frame(plot$data)) {
+    return(.ardmr_coerce_data_list(plot$data))
+  }
+
+  built <- tryCatch(ggplot2::ggplot_build(plot), error = function(e) NULL)
+  if (!is.null(built) && length(built$data)) {
+    built_list <- .ardmr_coerce_data_list(built$data)
+    if (length(built_list)) return(built_list)
+  }
+
+  list()
+}
+
+#' @keywords internal
+.ardmr_write_plot_data <- function(plot, dir_path, base_name, fallback = NULL) {
+  data_list <- .ardmr_collect_plot_data(plot, fallback)
+  if (!length(data_list)) return(invisible(NULL))
+
+  if (!dir.exists(dir_path)) {
+    dir.create(dir_path, recursive = TRUE, showWarnings = FALSE)
+  }
+
+  nms <- names(data_list)
+  if (is.null(nms)) nms <- rep("", length(data_list))
+  if (!length(data_list)) return(invisible(NULL))
+
+  # ensure unique, sanitized names
+  if (length(data_list) == 1L) {
+    dataset_names <- "data"
+  } else {
+    dataset_names <- ifelse(nzchar(nms), nms, paste0("dataset", seq_along(data_list)))
+    dataset_names <- make.unique(dataset_names, sep = "_")
+  }
+
+  for (i in seq_along(data_list)) {
+    df <- data_list[[i]]
+    if (!is.data.frame(df)) next
+    nm <- if (length(data_list) == 1L) {
+      "data"
+    } else {
+      dataset_names[i]
+    }
+    file_stub <- if (length(data_list) == 1L) {
+      paste0(base_name, "__data")
+    } else {
+      paste0(base_name, "__", .ardmr_sanitize_component(nm))
+    }
+    file_path <- file.path(dir_path, paste0(file_stub, ".csv"))
+    if (requireNamespace("readr", quietly = TRUE)) {
+      readr::write_csv(df, file_path)
+    } else {
+      utils::write.csv(df, file_path, row.names = FALSE)
+    }
+  }
+
+  invisible(NULL)
+}

--- a/R/plots.R
+++ b/R/plots.R
@@ -271,6 +271,15 @@ manhattan_plot <- function(results_df,
     ggplot2::coord_cartesian(ylim = c(-0.1, y_max * 1.05), clip = "off")
 
   if (verbose) logger::log_info("Manhattan: plot object constructed; returning ggplot.")
+  p <- .ardmr_attach_plot_data(
+    p,
+    main = df,
+    significant = sig_df,
+    l2_map = l2_map,
+    segments = seg_l2,
+    teeth = teeth_l2,
+    labels = lab_l2
+  )
   p
 }
 
@@ -361,7 +370,7 @@ plot_enrichment_directional_forest <- function(
       )
   }
 
-  p +
+  p <- p +
     ggplot2::scale_x_continuous("SES z-score (− protective  ←  0  →  risk +)",
                                 expand = ggplot2::expansion(mult = c(0.05,0.1))) +
     ggplot2::ylab(y_lab) +
@@ -375,6 +384,8 @@ plot_enrichment_directional_forest <- function(
       legend.title = ggplot2::element_text(size = 11),
       legend.text  = ggplot2::element_text(size = 11)
     )
+  p <- .ardmr_attach_plot_data(p, main = df, segments = seg)
+  p
 }
 
 
@@ -462,7 +473,7 @@ plot_enrichment_signed_forest <- function(
       )
   }
 
-  p +
+  p <- p +
     ggplot2::scale_x_continuous("SES z-score (− protective  ←  0  →  risk +)",
                                 expand = ggplot2::expansion(mult = c(0.05,0.1))) +
     ggplot2::ylab(y_lab) +
@@ -476,6 +487,8 @@ plot_enrichment_signed_forest <- function(
       legend.title = ggplot2::element_text(size = 11),
       legend.text  = ggplot2::element_text(size = 11)
     )
+  p <- .ardmr_attach_plot_data(p, main = df, segments = seg)
+  p
 }
 
 
@@ -544,7 +557,7 @@ plot_enrichment_global_signed <- function(
       )
   }
 
-  p +
+  p <- p +
     ggplot2::scale_x_continuous("SES z-score (− protective  ←  0  →  risk +)",
                                 expand = ggplot2::expansion(mult = c(0.05,0.1))) +
     ggplot2::labs(title = title, y = NULL) +
@@ -556,6 +569,8 @@ plot_enrichment_global_signed <- function(
       legend.title = ggplot2::element_text(size = 11),
       legend.text  = ggplot2::element_text(size = 11)
     )
+  p <- .ardmr_attach_plot_data(p, main = df, segment = seg)
+  p
 }
 
 
@@ -699,6 +714,7 @@ volcano_plot <- function(results_df,
   }
 
   # Labels for most significant points (if results_outcome exists)
+  lab_df <- tibble::tibble()
   if ("results_outcome" %in% names(df)) {
     lab_df <- dplyr::filter(df, .data$sig %in% TRUE & !is.na(.data$results_outcome))
     if (nrow(lab_df)) {
@@ -723,6 +739,7 @@ volcano_plot <- function(results_df,
     }
   }
 
+  p <- .ardmr_attach_plot_data(p, main = df, labelled = lab_df)
   p
 }
 
@@ -789,7 +806,7 @@ plot_enrichment_global <- function(
       )
   }
 
-  p +
+  p <- p +
     ggplot2::scale_x_continuous("SES z-score (− protective  ←  0  →  risk +)",
                                 expand = ggplot2::expansion(mult = c(0.05,0.1))) +
     ggplot2::labs(title = title, y = NULL) +
@@ -801,6 +818,8 @@ plot_enrichment_global <- function(
       legend.title = ggplot2::element_text(size = 11),
       legend.text  = ggplot2::element_text(size = 11)
     )
+  p <- .ardmr_attach_plot_data(p, main = df, segments = seg)
+  p
 }
 
 # ---------- forest for Δβ (inside vs outside) ----------
@@ -885,7 +904,8 @@ plot_beta_contrast_forest <- function(
       ) +
       ggplot2::theme(axis.text.y = ggplot2::element_text(colour = lab_col))
   }
-  
+
+  p <- .ardmr_attach_plot_data(p, main = df)
   p
 }
 

--- a/R/run_phenome_mr.R
+++ b/R/run_phenome_mr.R
@@ -365,9 +365,11 @@ run_phenome_mr <- function(
 
       dir_path  <- file.path(base_dir, dirname(subpath))
       if (!dir.exists(dir_path)) dir.create(dir_path, recursive = TRUE, showWarnings = FALSE)
-      file_name <- paste0(safe_name(basename(subpath)), ".png")
+      file_stem <- safe_name(basename(subpath))
+      file_name <- paste0(file_stem, ".png")
       file_path <- file.path(dir_path, file_name)
       ggplot2::ggsave(filename = file_path, plot = x, width = width, height = height, dpi = 300)
+      .ardmr_write_plot_data(x, dir_path = dir_path, base_name = file_stem)
       return(invisible(NULL))
     }
 


### PR DESCRIPTION
## Summary
- add internal helpers to attach data frames to ggplots and emit CSV copies alongside saved images
- write companion CSVs when saving diagnostic plots and summary outputs
- tag the data driving manhattan, volcano, enrichment, and beta-contrast plots so the exporter can pick them up

## Testing
- `Rscript -e "devtools::load_all()"` *(fails: Rscript not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cae34fee84832cb67329b5bc72089d