### PR TITLE
Refactor run_phenome_mr output directory layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,12 +58,12 @@ exposure <- tibble::tibble(
 
 # 2) Run phenome-wide MR
 res <- run_phenome_mr(
+  exposure = "LDL-C",
   exposure_snps = exposure,
   sex = "both",                # "both" => Pan-UKB, "male"/"female" => Neale
   ancestry = "EUR",
   sensitivity_pass_min = 6,
   multiple_testing_correction = "BH",
-  plot_output_dir = "output/", # optional
   neale_gwas_dir = NULL        # required if sex != "both"
 )
 
@@ -71,6 +71,9 @@ res$results_df      # tidy results across outcomes
 res$volcano         # ggplot
 res$manhattan       # ggplot
 ```
+
+All run-specific plots, diagnostics, and logs are written to
+`<cache_dir>/output/<exposure>/<sex>/<ancestry>`.
 
 `run_phenome_mr()` builds `MR_df` from phenotypes defined by the Global Burden of Disease (GBD) cause ontology. Age-related diseases and other outcomes share this structure and are distinguished by an `ARD_selected` flag, so the instructions above apply uniformly across phenotypes.`
 
@@ -422,9 +425,10 @@ Pass gate: **≥ `sensitivity_pass_min`** of enabled checks.
 
 ## Logging & outputs
 
-* `results_df` (CSV if `plot_output_dir` set)
+* `results_df` CSV and summary tables saved under
+  `<cache_dir>/output/<exposure>/<sex>/<ancestry>`
 * Optional per-outcome harmonised RDS (hook available)
-* Console logs for mapping counts, downloads/indexing, QC summaries
+* Console and file logs stored alongside run outputs
 
 ---
 

--- a/man/run_phenome_mr.Rd
+++ b/man/run_phenome_mr.Rd
@@ -5,6 +5,7 @@
 \title{Run phenome-wide MR across phenotypes (orchestrator)}
 \usage{
 run_phenome_mr(
+  exposure,
   exposure_snps,
   ancestry,
   sex = c("both", "male", "female"),
@@ -23,6 +24,9 @@ run_phenome_mr(
 )
 }
 \arguments{
+\item{exposure}{Character (mandatory) label for the exposure; used for naming
+output directories and plot titles.}
+
 \item{exposure_snps}{Data frame of exposure instruments (TwoSampleMR-like: rsid, beta, se, effect_allele, other_allele, eaf, etc.).}
 
 \item{ancestry}{Character (mandatory), e.g. "EUR".}
@@ -36,8 +40,6 @@ run_phenome_mr(
 \item{Multiple_testing_correction}{"BH" or "bonferroni" (default "BH").}
 
 \item{scatterplot, snpforestplot, leaveoneoutplot}{Logical; produce per-outcome diagnostics.}
-
-\item{plot_output_dir}{Directory to write plots ("" = do not write).}
 
 \item{Neale_GWAS_dir}{Optional path to Neale sumstats; created if missing.}
 


### PR DESCRIPTION
## Summary
- add a required `exposure` argument to `run_phenome_mr()` and derive per-run outputs in `<cache_dir>/output/<exposure>/<sex>/<ancestry>`
- route log files into the same run-scoped directory and use the new exposure label when generating plots, enrichment, and contrast artefacts
- refresh the README and Rd documentation to explain the new API and output locations

## Testing
- Rscript -e "devtools::test()" *(fails: `Rscript` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc39986324832c9e8cca6dcb1e1eba