### PR TITLE
Add wrapped beta compare plots with 27-character wrapping

### DIFF
--- a/R/ard_compare.R
+++ b/R/ard_compare.R
@@ -378,19 +378,23 @@ ard_compare <- function(
 
   # build and save plots
   if (nrow(global_combined)) {
-    plot_global <- plot_beta_mean_global_compare(global_combined)
     out_dir <- file.path(beta_compare_dir, "global")
+    plot_global <- plot_beta_mean_global_compare(global_combined)
     save_plot(plot_global, out_dir, "mean_effect", nrow(global_combined))
+    plot_global_wrap <- plot_beta_mean_global_compare_wrap(global_combined)
+    save_plot(plot_global_wrap, out_dir, "mean_effect_wrap", nrow(global_combined))
   }
 
   for (lvl in cause_levels) {
     for (sc in scopes) {
       plot_df <- cause_datasets[[lvl]][[sc]]$plot
       if (!nrow(plot_df)) next
-      plot_obj <- plot_beta_mean_cause_compare(plot_df)
       out_dir <- file.path(beta_compare_dir, lvl, sc)
       n_rows <- nrow(plot_df)
+      plot_obj <- plot_beta_mean_cause_compare(plot_df)
       save_plot(plot_obj, out_dir, "mean_effect", n_rows)
+      plot_obj_wrap <- plot_beta_mean_cause_compare_wrap(plot_df)
+      save_plot(plot_obj_wrap, out_dir, "mean_effect_wrap", n_rows)
     }
   }
 

--- a/R/plots.R
+++ b/R/plots.R
@@ -1149,6 +1149,47 @@ plot_beta_mean_global_compare <- function(
   p
 }
 
+#' Wrapped-axis companion to `plot_beta_mean_global_compare()`
+#'
+#' Applies a 27-character wrap to the displayed group labels while keeping
+#' the attached data unchanged.
+#'
+#' @inheritParams plot_beta_mean_global_compare
+#' @keywords internal
+plot_beta_mean_global_compare_wrap <- function(
+    beta_global_tbl,
+    title = NULL
+) {
+  df <- tibble::as_tibble(beta_global_tbl)
+  p <- plot_beta_mean_global_compare(
+    beta_global_tbl = df,
+    title = title
+  )
+
+  plot_data <- attr(p, "ardmr_plot_data", exact = TRUE)
+  if (!nrow(df)) {
+    if (!is.null(plot_data)) {
+      attr(p, "ardmr_plot_data") <- plot_data
+    }
+    return(p)
+  }
+
+  levels_vec <- rev(df$display_label)
+  levels_vec <- unique(levels_vec)
+  axis_labels <- stats::setNames(levels_vec, levels_vec)
+  wrapped_labels <- stringr::str_wrap(unname(axis_labels), width = 27)
+  names(wrapped_labels) <- names(axis_labels)
+
+  p_wrapped <- p + ggplot2::scale_y_discrete(
+    limits = levels_vec,
+    labels = wrapped_labels
+  )
+  if (!is.null(plot_data)) {
+    attr(p_wrapped, "ardmr_plot_data") <- plot_data
+  }
+  p_wrapped
+}
+
 #' @keywords internal
 plot_beta_mean_cause_compare <- function(
     beta_cause_tbl,
@@ -1217,5 +1258,50 @@ plot_beta_mean_cause_compare <- function(
 
   p <- .ardmr_attach_plot_data(p, main = df)
   p
+}
+
+#' Wrapped-axis companion to `plot_beta_mean_cause_compare()`
+#'
+#' Applies a 27-character wrap to the displayed cause labels while keeping
+#' the attached data unchanged.
+#'
+#' @inheritParams plot_beta_mean_cause_compare
+#' @keywords internal
+plot_beta_mean_cause_compare_wrap <- function(
+    beta_cause_tbl,
+    title = NULL,
+    subtitle = NULL
+) {
+  df <- tibble::as_tibble(beta_cause_tbl)
+  p <- plot_beta_mean_cause_compare(
+    beta_cause_tbl = df,
+    title = title,
+    subtitle = subtitle
+  )
+
+  plot_data <- attr(p, "ardmr_plot_data", exact = TRUE)
+  if (!nrow(df)) {
+    if (!is.null(plot_data)) {
+      attr(p, "ardmr_plot_data") <- plot_data
+    }
+    return(p)
+  }
+
+  df$is_separator <- df$is_separator %in% TRUE
+  axis_levels <- rev(df$axis_id)
+  axis_levels <- unique(axis_levels)
+  axis_labels <- stats::setNames(df$axis_label, df$axis_id)
+  axis_labels <- axis_labels[axis_levels]
+  wrapped_labels <- stringr::str_wrap(unname(axis_labels), width = 27)
+  names(wrapped_labels) <- names(axis_labels)
+
+  p_wrapped <- p + ggplot2::scale_y_discrete(
+    limits = axis_levels,
+    labels = wrapped_labels
+  )
+  if (!is.null(plot_data)) {
+    attr(p_wrapped, "ardmr_plot_data") <- plot_data
+  }
+  p_wrapped
 }
 


### PR DESCRIPTION
## Summary
- add wrapped companions for the ARD compare global and cause-level beta plots that apply 27-character label wrapping
- export both the default and _wrap PNGs for each compare plot so the wrapped variants are saved alongside existing outputs

## Testing
- Rscript -e "devtools::load_all()" *(fails: command not found: Rscript)*

------
https://chatgpt.com/codex/tasks/task_e_68cdaaaa07cc832c9e6ec51455130fbc