### PR TITLE
Adjust Bonferroni legend title

### DIFF
--- a/R/plots.R
+++ b/R/plots.R
@@ -412,7 +412,7 @@ manhattan_plot_recolor <- function(results_df,
   legend_title <- if (Multiple_testing_correction == "BH") {
     "Significance & direction (FDR < 0.05)"
   } else {
-    "Significance & direction:"
+    NULL
   }
 
   exposure_lab <- tryCatch(as.character(exposure)[1], error = function(e) NA_character_)


### PR DESCRIPTION
## Summary
- set the Bonferroni legend title to NULL so those plots omit the heading while keeping the FDR label for BH plots

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cdce976534832c82c569fcb5055e12