### PR TITLE
Add validation for mixed sex values in ard_compare

### DIFF
--- a/R/ard_compare.R
+++ b/R/ard_compare.R
@@ -174,6 +174,14 @@ ard_compare <- function(
     )
   }
 
+  sex_values <- vapply(groups_info, function(info) info$sex, character(1))
+  if (any(sex_values == "both") && !all(sex_values == "both")) {
+    stop(
+      "comparisons of panukb and neale not allowed: check sex values to ensure one catalog only",
+      call. = FALSE
+    )
+  }
+
   # ensure sex/both consistency for non-EUR ancestries
   for (info in groups_info) {
     if (!identical(info$ancestry, "EUR") && !identical(info$sex, "both")) {


### PR DESCRIPTION
## Summary
- ensure `ard_compare()` stops when groups mix `sex = "both"` with other values
- align the error message with catalog comparison guidance

## Testing
- `Rscript -e "devtools::test()"` *(fails: Rscript not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ced8830490832ca887db294c1bfd3d