### PR TITLE
Add beta wrap yfloat plots with dynamic heights

### DIFF
--- a/R/run_phenome_mr.R
+++ b/R/run_phenome_mr.R
@@ -410,7 +410,19 @@ run_phenome_mr <- function(
       exposure_units = exposure_units,
       effect_scale = beta_effect_scale
     )
+    beta_plots[[lv]][["all_diseases_wrap_yfloat"]] <- plot_beta_mean_forest_wrap_yfloat(
+      tbl_all,
+      title = sprintf("Mean effect of %s on all disease by %s", exposure, pretty_level(lv)),
+      exposure_units = exposure_units,
+      effect_scale = beta_effect_scale
+    )
     beta_plots[[lv]][["age_related_diseases_wrap"]] <- plot_beta_mean_forest_wrap(
+      tbl_ard,
+      title = sprintf("Mean effect of %s on ARDs by %s", exposure, pretty_level(lv)),
+      exposure_units = exposure_units,
+      effect_scale = beta_effect_scale
+    )
+    beta_plots[[lv]][["age_related_diseases_wrap_yfloat"]] <- plot_beta_mean_forest_wrap_yfloat(
       tbl_ard,
       title = sprintf("Mean effect of %s on ARDs by %s", exposure, pretty_level(lv)),
       exposure_units = exposure_units,
@@ -543,6 +555,17 @@ run_phenome_mr <- function(
       if (!is.null(file_stem_override)) file_stem <- file_stem_override
       file_name <- paste0(file_stem, ".png")
       file_path <- file.path(dir_path, file_name)
+      is_yfloat <- length(path_labels) >= 1 && grepl("_wrap_yfloat$", tail(path_labels, 1))
+      if (is_yfloat) {
+        plot_data <- attr(x, "ardmr_plot_data", exact = TRUE)
+        main_df <- NULL
+        if (is.list(plot_data) && "main" %in% names(plot_data)) {
+          main_df <- plot_data$main
+        }
+        n_rows <- if (is.data.frame(main_df)) nrow(main_df) else 0L
+        if (!is.finite(n_rows) || n_rows <= 0) n_rows <- 1L
+        height <- 1.2 + 0.28 * n_rows
+      }
       ggplot2::ggsave(filename = file_path, plot = x, width = width, height = height, dpi = 300)
       .ardmr_write_plot_data(x, dir_path = dir_path, base_name = file_stem)
       return(invisible(NULL))


### PR DESCRIPTION
## Summary
- add y-float variants of beta mean forests for all and ARD-only cause-level plots
- adjust plot saving helper to detect `_wrap_yfloat` files and size them based on row counts

## Testing
- `Rscript -e "testthat::test_dir('tests/testthat', reporter='summary')"` *(fails: missing Rsamtools dependency in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68cf221f67d4832ca55c8232e4378281