### PR TITLE
Use lowercase cause level labels in phenome plots

### DIFF
--- a/R/run_phenome_mr.R
+++ b/R/run_phenome_mr.R
@@ -357,12 +357,14 @@ run_phenome_mr <- function(
 
 
   pretty_level <- function(lv) {
-    switch(lv,
-           cause_level_1 = "Cause Level 1",
-           cause_level_2 = "Cause Level 2",
-           cause_level_3 = "Cause Level 3",
-           gsub("_", " ", lv)
+    pretty <- switch(
+      lv,
+      cause_level_1 = "cause level 1",
+      cause_level_2 = "cause level 2",
+      cause_level_3 = "cause level 3",
+      gsub("_", " ", lv, fixed = TRUE)
     )
+    tolower(pretty)
   }
 
   for (lv in cause_levels) {


### PR DESCRIPTION
## Summary
- ensure cause-level labels used in phenome-wide MR plots stay lowercase after replacing underscores with spaces

## Testing
- Rscript -e "devtools::test()" *(fails: Rscript not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfb8670f88832caea980ebc5f2f0ef