### PR TITLE
Update enrichment violin default subtitles

### DIFF
--- a/R/plots.R
+++ b/R/plots.R
@@ -991,7 +991,7 @@ plot_enrichment_signed_violin_global <- function(
     title <- sprintf("Global enrichment of %s", exp_label)
   }
   if (is.null(subtitle)) {
-    subtitle <- sprintf("ARD vs non-ARD · two-sided permutation test (BH q < %.2f highlighted)", alpha)
+    subtitle <- "ARD vs non-ARD, two-sided permutation test"
   }
 
   p <- .build_enrichment_violin_plot(draws, obs, orientation = orientation, alpha = alpha) +
@@ -1053,8 +1053,7 @@ plot_enrichment_signed_violin_by_cause <- function(
     title <- sprintf("Cause level %d signed enrichment of %s", .level_number(level), exp_label)
   }
   if (is.null(subtitle)) {
-    subtitle <- sprintf("%s · two-sided permutation test (BH q < %.2f highlighted)",
-                        .pretty_compare(compare_mode), alpha)
+    subtitle <- "Within-cause effect size vs all-cause effect size, two-sided permutation test"
   }
 
   p <- .build_enrichment_violin_plot(draws, obs, orientation = orientation, alpha = alpha) +


### PR DESCRIPTION
## Summary
- adjust the default subtitle for global enrichment violin plots to describe the ARD vs non-ARD comparison
- update the default subtitle for cause-level enrichment violin plots to describe within-cause vs all-cause effect sizes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d15ddebb90832c90d326aff78acbbe