### PR TITLE
Wrap cause-level forest violin labels

### DIFF
--- a/R/plots.R
+++ b/R/plots.R
@@ -1063,7 +1063,9 @@ plot_enrichment_signed_violin_by_cause <- function(
   if (orientation == "vertical") {
     p <- p + ggplot2::theme(axis.text.x = ggplot2::element_text(angle = 45, hjust = 1, vjust = 1, size = 9))
   } else {
-    p <- p + ggplot2::theme(axis.text.y = ggplot2::element_text(size = 9))
+    p <- p +
+      ggplot2::scale_y_discrete(labels = function(x) stringr::str_wrap(x, width = 27)) +
+      ggplot2::theme(axis.text.y = ggplot2::element_text(size = 9))
   }
 
   .ardmr_attach_plot_data(p, draws = draws, observed = obs)


### PR DESCRIPTION
## Summary
- wrap the y-axis labels for the forest-orientation cause-level signed enrichment violin plot to 27 characters to mirror the global view

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d15e44e408832ca90cd61477dafda3