### PR TITLE
Drop forced legend entries for enrichment violin plot

### DIFF
--- a/R/plots.R
+++ b/R/plots.R
@@ -889,6 +889,7 @@ plot_enrichment_global_signed <- function(
     sig_labels[1], sig_labels[2]
   )
   obs_df$signif_label <- factor(obs_df$signif_label, levels = sig_labels)
+  obs_df$signif_label <- base::droplevels(obs_df$signif_label)
 
   colour_map <- stats::setNames(c("firebrick", "grey30"), sig_labels)
 
@@ -942,8 +943,7 @@ plot_enrichment_global_signed <- function(
   base +
     ggplot2::scale_colour_manual(
       name = sprintf("BH (q < %.2f)", alpha),
-      values = colour_map,
-      drop = FALSE
+      values = colour_map
     )
 }
 


### PR DESCRIPTION
## Summary
- allow ggplot2 to drop unused legend keys in enrichment violin plots by removing the manual drop override
- drop unused significance labels before plotting to keep colour mappings aligned

## Testing
- Rscript -e "devtools::test()" *(fails: `Rscript` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d15dae8700832c8b745a6f4e28d97a