### PR TITLE
Update enrichment heatmaps for BH display and layout

### DIFF
--- a/R/ard_compare.R
+++ b/R/ard_compare.R
@@ -99,6 +99,11 @@ ard_compare <- function(
     dir.create(beta_compare_dir, recursive = TRUE, showWarnings = FALSE)
   }
 
+  enrichment_heatmap_dir <- file.path(compare_root, "enrichment_heatmap")
+  if (!dir.exists(enrichment_heatmap_dir)) {
+    dir.create(enrichment_heatmap_dir, recursive = TRUE, showWarnings = FALSE)
+  }
+
   ancestry_label <- function(sex, ancestry) {
     sx <- tolower(trimws(sex))
     anc <- toupper(trimws(ancestry))
@@ -276,7 +281,26 @@ ard_compare <- function(
     )
   }
 
+  load_group_enrichment <- function(info) {
+    rds_path <- file.path(info$group_dir, "results.rds")
+    if (!file.exists(rds_path)) {
+      return(tibble::tibble())
+    }
+
+    res <- tryCatch(readRDS(rds_path), error = function(e) NULL)
+    if (!is.list(res) || is.null(res$enrich)) {
+      return(tibble::tibble())
+    }
+    enrich <- res$enrich
+    if (!is.list(enrich) || !is.data.frame(enrich$by_cause_tbl)) {
+      return(tibble::tibble())
+    }
+
+    tibble::as_tibble(enrich$by_cause_tbl)
+  }
+
   group_tables <- lapply(groups_info, load_group_tables)
+  group_enrichment <- lapply(groups_info, load_group_enrichment)
 
   # combine global tables
   combine_global <- function(group_tables, groups_info) {
@@ -380,6 +404,112 @@ ard_compare <- function(
     list(table = combined, plot = plot_df)
   }
 
+  format_p_label <- function(p) {
+    out <- rep("NA", length(p))
+    ok <- is.finite(p)
+    if (any(ok)) {
+      hi <- ok & p >= 0.001
+      lo <- ok & !hi
+      out[hi] <- sprintf("%.3f", p[hi])
+      out[lo] <- sprintf("%.2e", p[lo])
+    }
+    out
+  }
+
+  build_heatmap_dataset <- function(
+      level,
+      scope,
+      cause_datasets,
+      group_enrichment,
+      groups_info,
+      exposure_label,
+      compare_mode = "cause_vs_rest_all",
+      p_threshold = 0.05
+  ) {
+    cause_tbl <- cause_datasets[[level]][[scope]]$table
+    if (!is.data.frame(cause_tbl) || !nrow(cause_tbl)) {
+      return(tibble::tibble())
+    }
+
+    causes <- unique(cause_tbl$cause)
+    causes <- causes[!is.na(causes)]
+    causes <- trimws(as.character(causes))
+    causes <- causes[nzchar(causes)]
+    if (!length(causes)) {
+      return(tibble::tibble())
+    }
+
+    cause_order <- stats::setNames(seq_along(causes), causes)
+
+    rows <- vector("list", length(groups_info))
+    for (i in seq_along(groups_info)) {
+      info <- groups_info[[i]]
+      enrich_tbl <- group_enrichment[[i]]
+      if (is.data.frame(enrich_tbl) && nrow(enrich_tbl) &&
+          all(c("level","compare_mode","cause") %in% names(enrich_tbl))) {
+        enrich_tbl <- enrich_tbl[
+          enrich_tbl$level == level &
+            enrich_tbl$compare_mode == compare_mode,
+          ,
+          drop = FALSE
+        ]
+      } else {
+        enrich_tbl <- tibble::tibble()
+      }
+
+      if (nrow(enrich_tbl)) {
+        enrich_tbl$cause <- trimws(as.character(enrich_tbl$cause))
+      }
+
+      match_idx <- if (nrow(enrich_tbl)) match(causes, enrich_tbl$cause) else rep(NA_integer_, length(causes))
+      pull_vals <- function(col, default = NA_real_) {
+        if (!nrow(enrich_tbl) || is.null(enrich_tbl[[col]])) {
+          rep(default, length(causes))
+        } else {
+          vals <- rep(default, length(causes))
+          ok <- !is.na(match_idx)
+          if (any(ok)) {
+            vals[ok] <- enrich_tbl[[col]][match_idx[ok]]
+          }
+          vals
+        }
+      }
+
+      p_vals <- pull_vals("p_signed")
+      q_vals <- pull_vals("q_signed")
+      ses_vals <- pull_vals("SES_signed")
+
+      rows[[i]] <- tibble::tibble(
+        level = level,
+        scope = scope,
+        compare_mode = compare_mode,
+        cause = causes,
+        cause_order = unname(cause_order[causes]),
+        group_id = info$id,
+        group_label = info$display,
+        group_order = info$index,
+        p_signed = p_vals,
+        q_signed = q_vals,
+        SES_signed = ses_vals,
+        significant = is.finite(q_vals) & (q_vals < p_threshold),
+        direction = dplyr::case_when(
+          is.finite(ses_vals) & ses_vals < 0 ~ "protective",
+          is.finite(ses_vals) & ses_vals > 0 ~ "risk",
+          TRUE ~ "neutral"
+        ),
+        label = format_p_label(q_vals),
+        exposure = exposure_label
+      )
+    }
+
+    out <- dplyr::bind_rows(rows)
+    if (!nrow(out)) {
+      return(tibble::tibble())
+    }
+    out$direction[out$significant %in% FALSE] <- "neutral"
+    out
+  }
+
   cause_levels <- c("cause_level_1","cause_level_2","cause_level_3")
   scopes <- c("all_diseases","age_related_diseases")
   cause_datasets <- list()
@@ -387,6 +517,21 @@ ard_compare <- function(
     cause_datasets[[lvl]] <- list()
     for (sc in scopes) {
       cause_datasets[[lvl]][[sc]] <- make_cause_dataset(lvl, sc, group_tables, groups_info)
+    }
+  }
+
+  heatmap_datasets <- list()
+  for (lvl in cause_levels) {
+    heatmap_datasets[[lvl]] <- list()
+    for (sc in scopes) {
+      heatmap_datasets[[lvl]][[sc]] <- build_heatmap_dataset(
+        level = lvl,
+        scope = sc,
+        cause_datasets = cause_datasets,
+        group_enrichment = group_enrichment,
+        groups_info = groups_info,
+        exposure_label = exposure
+      )
     }
   }
 
@@ -482,6 +627,26 @@ ard_compare <- function(
         effect_scale = compare_effect_scale
       )
       save_plot(plot_obj_wrap_yfloat, out_dir, "mean_effect_wrap_yfloat", n_rows)
+
+      heat_df <- heatmap_datasets[[lvl]][[sc]]
+      if (is.data.frame(heat_df) && nrow(heat_df)) {
+        heat_plot <- plot_enrichment_group_heatmap(
+          heat_df,
+          level = lvl,
+          scope = sc,
+          exposure = exposure
+        )
+        n_causes <- length(unique(heat_df$cause))
+        heat_dir <- file.path(enrichment_heatmap_dir, lvl, sc)
+        nature_single_col_width <- 3.54
+        save_plot(
+          heat_plot,
+          heat_dir,
+          "group_heatmap",
+          max(1, n_causes),
+          width = nature_single_col_width
+        )
+      }
     }
   }
 

--- a/R/plots.R
+++ b/R/plots.R
@@ -1071,6 +1071,117 @@ plot_enrichment_signed_violin_by_cause <- function(
 }
 
 
+#' Heatmap of signed enrichment p-values across compare groups
+#'
+#' @param heatmap_df Data frame containing one row per cause × group cell.
+#'   Expected columns include: `cause`, `group_label`, `p_signed`,
+#'   `SES_signed`, `significant`, `direction`, `label`, `cause_order`,
+#'   `group_order`.
+#' @param level Cause level identifier (e.g., "cause_level_1").
+#' @param scope Scope string ("all_diseases" or "age_related_diseases").
+#' @param exposure Optional exposure label for the title.
+#' @param title,subtitle Optional strings overriding the defaults.
+#' @keywords internal
+plot_enrichment_group_heatmap <- function(
+    heatmap_df,
+    level,
+    scope,
+    exposure = NULL,
+    title = NULL,
+    subtitle = NULL
+) {
+  df <- tibble::as_tibble(heatmap_df)
+  required <- c(
+    "cause","group_label","p_signed","q_signed","SES_signed",
+    "significant","direction","label","cause_order","group_order"
+  )
+  if (!all(required %in% names(df))) {
+    stop("plot_enrichment_group_heatmap(): heatmap_df missing required columns.", call. = FALSE)
+  }
+  if (!nrow(df)) {
+    return(ggplot2::ggplot() + ggplot2::theme_void())
+  }
+
+  df$cause <- as.character(df$cause)
+  df$group_label <- as.character(df$group_label)
+  cause_levels <- unique(df$cause[order(df$cause_order, df$cause)])
+  group_levels <- unique(df$group_label[order(df$group_order, df$group_label)])
+  df$cause_f <- factor(df$cause, levels = rev(cause_levels))
+  df$group_f <- factor(df$group_label, levels = group_levels)
+  df$significant <- is.finite(df$q_signed) & df$q_signed < 0.05
+
+  dir_vals <- ifelse(df$direction %in% c("protective","risk"), df$direction, "neutral")
+  dir_vals[!df$significant] <- "neutral"
+  df$fill_state <- factor(dir_vals, levels = c("protective","neutral","risk"))
+
+  palette <- c(
+    protective = "#c6dbef",
+    neutral = "#e0e0e0",
+    risk = "#fcbba1"
+  )
+
+  exp_label <- tryCatch(as.character(exposure)[1], error = function(e) NA_character_)
+  if (is.null(exp_label) || is.na(exp_label) || !nzchar(exp_label)) {
+    exp_label <- "exposure"
+  }
+
+  if (is.null(title)) {
+    lvl_num <- suppressWarnings(.level_number(level))
+    if (is.na(lvl_num) || !is.finite(lvl_num)) {
+      title <- sprintf("Enrichment heatmap for %s", exp_label)
+    } else {
+      title <- sprintf("Cause level %d enrichment heatmap for %s", lvl_num, exp_label)
+    }
+  }
+
+  if (is.null(subtitle)) {
+    scope_label <- switch(
+      scope,
+      age_related_diseases = "Age-related diseases",
+      all_diseases = "All diseases",
+      scope
+    )
+    subtitle <- sprintf("%s scope · cause vs rest (two-sided permutation p)", scope_label)
+  }
+
+  df$label <- as.character(df$label)
+  df$label[is.na(df$label) | !nzchar(df$label)] <- "NA"
+
+  p <- ggplot2::ggplot(df, ggplot2::aes(x = group_f, y = cause_f, fill = fill_state)) +
+    ggplot2::geom_tile(color = "white", linewidth = 0.4) +
+    ggplot2::geom_text(ggplot2::aes(label = label), size = 3.2, colour = "#1a1a1a") +
+    ggplot2::scale_fill_manual(
+      values = palette,
+      limits = c("protective","neutral","risk"),
+      breaks = c("protective","neutral","risk"),
+      labels = c(
+        "Protective (BH p-val < .05)",
+        "Not significant / NA",
+        "Risk (BH p-val < .05)"
+      ),
+      name = NULL,
+      drop = FALSE
+    ) +
+    ggplot2::labs(
+      x = NULL,
+      y = NULL,
+      title = title,
+      subtitle = subtitle
+    ) +
+    ggplot2::scale_y_discrete(labels = function(x) stringr::str_wrap(x, width = 27)) +
+    ggplot2::theme_minimal(base_size = 11) +
+    ggplot2::theme(
+      panel.grid = ggplot2::element_blank(),
+      axis.text.x = ggplot2::element_text(angle = 45, hjust = 1, vjust = 1),
+      axis.text.y = ggplot2::element_text(hjust = 1),
+      legend.position = "top",
+      legend.title = ggplot2::element_blank(),
+      legend.text = ggplot2::element_text(size = 9)
+    )
+
+  .ardmr_attach_plot_data(p, main = df)
+}
+
 
 #' Volcano plot (IVW): effect size vs significance
 #'


### PR DESCRIPTION
## Summary
- route the enrichment heatmap outputs into their own enrichment_heatmap directory and export them at Nature single-column width
- base heatmap significance and cell labels on BH-adjusted q-values while retaining both p and q columns in the dataset
- wrap cause labels on the y axis and update the legend text to reflect BH significance without a title

## Testing
- Rscript -e "devtools::test()" *(fails: command not found: Rscript)*

------
https://chatgpt.com/codex/tasks/task_e_68d16d968970832c9fc44ec3df25c346