### PR TITLE
Narrow global compare violin width

### DIFF
--- a/R/ard_compare.R
+++ b/R/ard_compare.R
@@ -622,14 +622,16 @@ ard_compare <- function(
     }
   }
 
-  save_plot <- function(plot, dir_path, file_stem, n_rows, width = 6.0) {
+  save_plot <- function(plot, dir_path, file_stem, n_rows, width = 6.0, height = NULL) {
     if (!dir.exists(dir_path)) dir.create(dir_path, recursive = TRUE, showWarnings = FALSE)
     file_path <- file.path(dir_path, paste0(file_stem, ".png"))
     is_yfloat <- is.character(file_stem) && grepl("_wrap_yfloat$", file_stem)
-    height <- if (is_yfloat) {
-      1.2 + 0.28 * max(1, n_rows)
-    } else {
-      max(2.4, 1.2 + 0.28 * n_rows)
+    if (is.null(height)) {
+      height <- if (is_yfloat) {
+        1.2 + 0.28 * max(1, n_rows)
+      } else {
+        max(2.4, 1.2 + 0.28 * n_rows)
+      }
     }
     ggsave_args <- list(
       filename = file_path,
@@ -721,7 +723,8 @@ ard_compare <- function(
       file.path(enrichment_compare_dir, "global"),
       "violin_forest",
       n_groups,
-      width = 7.2
+      width = 3.54,
+      height = 1.8 + 0.28 * max(1, n_groups)
     )
   } else if (isTRUE(verbose)) {
     restore_compare_logging()

--- a/R/plots.R
+++ b/R/plots.R
@@ -872,7 +872,13 @@ plot_enrichment_global_signed <- function(
   list(draws = draws_df, observed = obs_df, levels = levels_use)
 }
 
-.build_enrichment_violin_plot <- function(draw_df, obs_df, orientation = c("vertical","forest"), alpha = 0.05) {
+.build_enrichment_violin_plot <- function(
+    draw_df,
+    obs_df,
+    orientation = c("vertical","forest"),
+    alpha = 0.05,
+    violin_width = 1.25
+) {
   orientation <- match.arg(orientation)
   if (!nrow(obs_df)) {
     placeholder <- ggplot2::ggplot() +
@@ -900,7 +906,13 @@ plot_enrichment_global_signed <- function(
 
   if (orientation == "vertical") {
     base <- ggplot2::ggplot(draw_df, ggplot2::aes(x = group_f, y = Tg_ses)) +
-      ggplot2::geom_violin(fill = "grey85", colour = "grey60", alpha = 0.9, trim = FALSE, width = 1.25) + #used to be width = .75
+      ggplot2::geom_violin(
+        fill = "grey85",
+        colour = "grey60",
+        alpha = 0.9,
+        trim = FALSE,
+        width = violin_width
+      ) +
       ggplot2::geom_hline(yintercept = 0, linetype = "dashed", linewidth = 0.4, colour = "grey50") +
       ggplot2::geom_segment(
         data = obs_df,
@@ -923,7 +935,13 @@ plot_enrichment_global_signed <- function(
       )
   } else {
     base <- ggplot2::ggplot(draw_df, ggplot2::aes(y = group_f, x = Tg_ses)) +
-      ggplot2::geom_violin(fill = "grey85", colour = "grey60", alpha = 0.9, trim = FALSE, width = 1.25) + #used to be width = .75
+      ggplot2::geom_violin(
+        fill = "grey85",
+        colour = "grey60",
+        alpha = 0.9,
+        trim = FALSE,
+        width = violin_width
+      ) +
       ggplot2::geom_vline(xintercept = 0, linetype = "dashed", linewidth = 0.4, colour = "grey50") +
       ggplot2::geom_segment(
         data = obs_df,
@@ -1093,7 +1111,13 @@ plot_enrichment_signed_violin_global_compare <- function(
     subtitle <- "ARD vs non-ARD, two-sided permutation test"
   }
 
-  p <- .build_enrichment_violin_plot(draws, obs, orientation = "forest", alpha = alpha) +
+  p <- .build_enrichment_violin_plot(
+    draws,
+    obs,
+    orientation = "forest",
+    alpha = alpha,
+    violin_width = 0.75
+  ) +
     ggplot2::labs(title = title, subtitle = subtitle) +
     ggplot2::scale_y_discrete(labels = function(x) stringr::str_wrap(x, width = 27)) +
     ggplot2::theme(axis.text.y = ggplot2::element_text(size = 10))


### PR DESCRIPTION
## Summary
- allow specifying a custom violin width when building enrichment violin plots
- narrow the global compare violin forest to width 0.75 without affecting other plots

## Testing
- Rscript -e "devtools::test()" *(fails: `Rscript` is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d19d840db4832cac50fcc35bc9b5f6