### PR TITLE
Increase ARD compare heatmap width

### DIFF
--- a/R/ard_compare.R
+++ b/R/ard_compare.R
@@ -715,7 +715,7 @@ ard_compare <- function(
         )
         n_causes <- length(unique(heat_df$cause))
         heat_out_dir <- file.path(enrich_compare_dir, lvl, sc)
-        save_plot(heat_plot, heat_out_dir, "group_heatmap", max(1, n_causes), width = 3.54)
+        save_plot(heat_plot, heat_out_dir, "group_heatmap", max(1, n_causes), width = 7.2)
       }
     }
   }


### PR DESCRIPTION
## Summary
- update `ard_compare()` to export group heatmaps at a 7.2 inch width to match the Nature double-column specification

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1ac4c75b4832cab8ac3fd48dceb6b