### PR TITLE
Stop saving beta plot exports

### DIFF
--- a/R/ard_compare.R
+++ b/R/ard_compare.R
@@ -665,19 +665,19 @@ ard_compare <- function(
       exposure_units = exposure_units,
       effect_scale = compare_effect_scale
     )
-    save_plot(plot_global, out_dir, "mean_effect", nrow(global_combined))
+    # save_plot(plot_global, out_dir, "mean_effect", nrow(global_combined))
     plot_global_wrap <- plot_beta_mean_global_compare_wrap(
       global_combined,
       exposure_units = exposure_units,
       effect_scale = compare_effect_scale
     )
-    save_plot(plot_global_wrap, out_dir, "mean_effect_wrap", nrow(global_combined))
+    # save_plot(plot_global_wrap, out_dir, "mean_effect_wrap", nrow(global_combined))
     plot_global_wrap_yfloat <- plot_beta_mean_global_compare_wrap_yfloat(
       global_combined,
       exposure_units = exposure_units,
       effect_scale = compare_effect_scale
     )
-    save_plot(plot_global_wrap_yfloat, out_dir, "mean_effect_wrap_yfloat", nrow(global_combined))
+    # save_plot(plot_global_wrap_yfloat, out_dir, "mean_effect_wrap_yfloat", nrow(global_combined))
   }
 
   for (lvl in cause_levels) {
@@ -691,19 +691,19 @@ ard_compare <- function(
         exposure_units = exposure_units,
         effect_scale = compare_effect_scale
       )
-      save_plot(plot_obj, out_dir, "mean_effect", n_rows)
+      # save_plot(plot_obj, out_dir, "mean_effect", n_rows)
       plot_obj_wrap <- plot_beta_mean_cause_compare_wrap(
         plot_df,
         exposure_units = exposure_units,
         effect_scale = compare_effect_scale
       )
-      save_plot(plot_obj_wrap, out_dir, "mean_effect_wrap", n_rows)
+      # save_plot(plot_obj_wrap, out_dir, "mean_effect_wrap", n_rows)
       plot_obj_wrap_yfloat <- plot_beta_mean_cause_compare_wrap_yfloat(
         plot_df,
         exposure_units = exposure_units,
         effect_scale = compare_effect_scale
       )
-      save_plot(plot_obj_wrap_yfloat, out_dir, "mean_effect_wrap_yfloat", n_rows)
+      # save_plot(plot_obj_wrap_yfloat, out_dir, "mean_effect_wrap_yfloat", n_rows)
 
       heat_df <- heatmap_datasets[[lvl]][[sc]]
       if (is.data.frame(heat_df) && nrow(heat_df)) {

--- a/R/run_phenome_mr.R
+++ b/R/run_phenome_mr.R
@@ -610,6 +610,11 @@ run_phenome_mr <- function(
         if (!is.finite(n_rows) || n_rows <= 0) n_rows <- 1L
         height <- yfloat_base + yfloat_coef * n_rows
       }
+      if (length(path_labels) >= 1 && identical(path_labels[1], "beta")) {
+        # ggplot2::ggsave(filename = file_path, plot = x, width = width, height = height, dpi = 300)
+        # .ardmr_write_plot_data(x, dir_path = dir_path, base_name = file_stem)
+        return(invisible(NULL))
+      }
       ggplot2::ggsave(filename = file_path, plot = x, width = width, height = height, dpi = 300)
       .ardmr_write_plot_data(x, dir_path = dir_path, base_name = file_stem)
       return(invisible(NULL))


### PR DESCRIPTION
## Summary
- skip writing beta plot images in `run_phenome_mr()` while leaving other plot exports intact
- prevent `ard_compare()` from saving beta comparison forest plots but keep enrichment visualisations

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1c4736bd4832cbf4cd54e6ebd5c6f