### PR TITLE
Update IEU compare runner to use CSV units and options

### DIFF
--- a/R/ard_compare_grouped_ieugwasr.R
+++ b/R/ard_compare_grouped_ieugwasr.R
@@ -1,6 +1,8 @@
 #' Build instruments from IEU GWAS, validate units, assemble groups, and run ard_compare()
 #'
-#' @param csv_path Path to a CSV with columns: ieu_id, Exposure, exposure_group, sex, ancestry
+#' @param csv_path Path to a CSV with columns: ieu_id, exposure, exposure_group,
+#'   sex, ancestry, multiple_testing_correction, confirm, and optionally
+#'   exposure_units
 #' @param cache_dir Output/cache directory used by ard_compare/run_phenome_mr
 #' @param jwt IEU JWT string; defaults to IEU_JWT/OPENGWAS_JWT env vars
 #' @param prompt_for_units If TRUE, interactively prompt for missing units; otherwise stop on missing units
@@ -50,7 +52,50 @@ run_ieugwasr_ard_compare <- function(
     (a1=="A"&a2=="T")|(a1=="T"&a2=="A")|(a1=="C"&a2=="G")|(a1=="G"&a2=="C")
   }
   f_stat <- function(beta, se) (beta/se)^2
-  safe_chr <- function(x) { x <- as.character(x); x[!nzchar(x)|is.na(x)] <- NA_character_; x }
+  safe_chr <- function(x) {
+    x <- trimws(as.character(x))
+    x[!nzchar(x) | is.na(x)] <- NA_character_
+    x
+  }
+  normalize_mtc <- function(x) {
+    x <- safe_chr(x)
+    if (!length(x)) return(NA_character_)
+    out <- vapply(x, function(val) {
+      if (is.na(val)) {
+        stop("multiple_testing_correction cannot be missing in the CSV.")
+      }
+      lv <- tolower(val)
+      if (lv %in% c("bh","fdr")) {
+        "BH"
+      } else if (lv %in% c("bonferroni","bonf")) {
+        "bonferroni"
+      } else if (val %in% c("BH","bonferroni")) {
+        val
+      } else {
+        stop(sprintf(
+          "Unsupported multiple_testing_correction value '%s'. Use 'BH' or 'bonferroni'.",
+          val
+        ))
+      }
+    }, character(1))
+    unname(out)
+  }
+  normalize_confirm <- function(x) {
+    x <- safe_chr(x)
+    if (!length(x)) return(NA_character_)
+    out <- vapply(x, function(val) {
+      if (is.na(val)) {
+        stop("confirm cannot be missing in the CSV.")
+      }
+      lv <- tolower(val)
+      if (lv %in% c("ask","yes","no")) {
+        lv
+      } else {
+        stop(sprintf("Unsupported confirm value '%s'. Use 'ask', 'yes', or 'no'.", val))
+      }
+    }, character(1))
+    unname(out)
+  }
 
   fetch_units <- function(ieu_id) {
     info <- try(ieugwasr::gwasinfo(ieu_id), silent = TRUE)
@@ -79,7 +124,7 @@ run_ieugwasr_ard_compare <- function(
     out <- raw %>%
       mutate(
         id.exposure            = ieu_id,
-        Exposure               = exposure_label,
+        exposure               = exposure_label,
         effect_allele.exposure = effect_allele,
         other_allele.exposure  = other_allele,
         eaf.exposure           = eaf,
@@ -91,14 +136,14 @@ run_ieugwasr_ard_compare <- function(
         F                      = f_stat(beta.exposure, se.exposure)
       ) %>%
       select(
-        id.exposure, Exposure, SNP, Chr, Pos,
+        id.exposure, exposure, SNP, Chr, Pos,
         effect_allele.exposure, other_allele.exposure, eaf.exposure,
         beta.exposure, se.exposure, palindromic, pval.exposure,
         mr_keep, F
       ) %>%
       arrange(SNP)
 
-    need <- c("id.exposure","Exposure","SNP","Chr","Pos",
+    need <- c("id.exposure","exposure","SNP","Chr","Pos",
               "effect_allele.exposure","other_allele.exposure","eaf.exposure",
               "beta.exposure","se.exposure","palindromic","pval.exposure",
               "mr_keep","F")
@@ -119,14 +164,50 @@ run_ieugwasr_ard_compare <- function(
 
   # ---- read CSV ----
   expos <- readr::read_csv(csv_path, show_col_types = FALSE)
-  req_cols <- c("ieu_id","Exposure","exposure_group","sex","ancestry")
+  req_cols <- c(
+    "ieu_id","exposure","exposure_group","sex","ancestry",
+    "multiple_testing_correction","confirm"
+  )
   miss_cols <- setdiff(req_cols, names(expos))
   if (length(miss_cols)) stop("CSV missing required columns: ", paste(miss_cols, collapse = ", "))
+  if (!"exposure_units" %in% names(expos)) {
+    expos$exposure_units <- NA_character_
+  }
+
+  expos <- expos %>%
+    mutate(
+      exposure = safe_chr(exposure),
+      exposure_group = safe_chr(exposure_group),
+      sex = safe_chr(sex),
+      ancestry = safe_chr(ancestry),
+      exposure_units = safe_chr(exposure_units),
+      multiple_testing_correction = normalize_mtc(multiple_testing_correction),
+      confirm = normalize_confirm(confirm)
+    )
+
+  if (any(is.na(expos$exposure))) {
+    stop("'exposure' column contains missing values.")
+  }
 
   # ---- units (preflight) ----
   unique_ids <- unique(expos$ieu_id)
   units_map <- setNames(rep(NA_character_, length(unique_ids)), unique_ids)
-  for (id in unique_ids) units_map[[id]] <- fetch_units(id)
+  for (id in unique_ids) {
+    csv_units <- unique(expos$exposure_units[expos$ieu_id == id])
+    csv_units <- csv_units[!is.na(csv_units) & csv_units != ""]
+    if (length(csv_units) > 1L) {
+      stop(sprintf(
+        "Exposure units differ for ieu_id '%s' in the CSV: %s",
+        id,
+        paste(csv_units, collapse = " | ")
+      ))
+    }
+    if (length(csv_units) == 1L) {
+      units_map[[id]] <- csv_units
+    } else {
+      units_map[[id]] <- fetch_units(id)
+    }
+  }
 
   need_units <- names(units_map)[is.na(units_map) | units_map == ""]
   if (length(need_units)) {
@@ -149,9 +230,9 @@ run_ieugwasr_ard_compare <- function(
     mutate(.row_id = dplyr::row_number()) %>%
     group_split(.row_id, keep = TRUE) %>%
     purrr::map(function(rr) {
-      r <- rr[[1]]
+      r <- dplyr::slice(rr, 1)
       ieu_id   <- r$ieu_id
-      exp_name <- r$Exposure
+      exp_name <- r$exposure
 
       ins <- get_instruments(ieu_id)
       if (!nrow(ins)) {
@@ -161,13 +242,18 @@ run_ieugwasr_ard_compare <- function(
 
       snps_df <- build_exposure_snps(ins, exposure_label = exp_name, ieu_id = ieu_id)
 
+      mtc_val <- normalize_mtc(r$multiple_testing_correction)[1]
+      confirm_val <- normalize_confirm(r$confirm)[1]
+
       list(
         exposure_group = r$exposure_group,
         sex            = match.arg(as.character(r$sex), c("both","male","female")),
         ancestry       = as.character(r$ancestry),
         exposure       = exp_name,
         exposure_units = units_map[[ieu_id]],
-        exposure_snps  = snps_df
+        exposure_snps  = snps_df,
+        multiple_testing_correction = mtc_val,
+        confirm        = confirm_val
       )
     }) %>%
     purrr::compact()
@@ -186,7 +272,7 @@ run_ieugwasr_ard_compare <- function(
     # exposure label (use first; warn if multiple)
     exp_label <- unique(vapply(entries, `[[`, "", "exposure"))
     if (length(exp_label) > 1L) {
-      warning(sprintf("Multiple 'Exposure' labels in group '%s'. Using the first: %s", grp_name, exp_label[1]))
+      warning(sprintf("Multiple 'exposure' labels in group '%s'. Using the first: %s", grp_name, exp_label[1]))
     }
     exposure_label <- exp_label[1]
 
@@ -196,6 +282,26 @@ run_ieugwasr_ard_compare <- function(
       stop(sprintf("Units differ within exposure_group '%s': %s", grp_name, paste(u_vals, collapse = " | ")))
     }
     exposure_units <- u_vals[1]
+
+    mtc_vals <- unique(vapply(entries, `[[`, "", "multiple_testing_correction"))
+    if (length(mtc_vals) > 1L) {
+      stop(sprintf(
+        "multiple_testing_correction values differ within exposure_group '%s': %s",
+        grp_name,
+        paste(mtc_vals, collapse = " | ")
+      ))
+    }
+    multiple_testing_correction <- mtc_vals[1]
+
+    confirm_vals <- unique(vapply(entries, `[[`, "", "confirm"))
+    if (length(confirm_vals) > 1L) {
+      stop(sprintf(
+        "confirm values differ within exposure_group '%s': %s",
+        grp_name,
+        paste(confirm_vals, collapse = " | ")
+      ))
+    }
+    confirm_val <- confirm_vals[1]
 
     # build groups list
     groups_list <- lapply(entries, function(e) {
@@ -223,14 +329,14 @@ run_ieugwasr_ard_compare <- function(
         "ivw_Q","ivw_I2"
       ),
       sensitivity_pass_min        = 6,
-      Multiple_testing_correction = "BH",
+      Multiple_testing_correction = multiple_testing_correction,
       scatterplot                 = TRUE,
       snpforestplot               = TRUE,
       leaveoneoutplot             = TRUE,
       cache_dir                   = cache_dir,
       logfile                     = NULL,
       verbose                     = TRUE,
-      confirm                     = "yes",
+      confirm                     = confirm_val,
       force_refresh               = FALSE
     )
 


### PR DESCRIPTION
## Summary
- require the IEU CSV to provide the lower-case `exposure` field plus `multiple_testing_correction` and `confirm` settings
- default exposure units to the CSV-supplied values, falling back to IEU metadata or an interactive prompt only when missing
- propagate the CSV-provided multiple testing correction and confirm flags to `ard_compare()` while enforcing consistent values within each group
- drop the legacy uppercase `Exposure` column from constructed instrument tables in favour of the lower-case `exposure`

## Testing
- `Rscript -e "devtools::test()"` *(fails: Rscript executable not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d1e932b2b0832c8e503cd472afe07c