### PR TITLE
Update IEU variant lookup to use variants_rsid

### DIFF
--- a/R/ard_compare_grouped_ieugwasr.R
+++ b/R/ard_compare_grouped_ieugwasr.R
@@ -108,7 +108,7 @@ run_ieugwasr_ard_compare <- function(
     NA_character_
   }
 
-  # chr/pos annotator: reuse if present, else reflookup(), else associations()
+  # chr/pos annotator: reuse if present, else variants_rsid(), else associations()
   annotate_chrpos <- function(dat) {
     # reuse if already present
     if (all(c("chr.exposure","pos.exposure") %in% names(dat))) {
@@ -123,10 +123,10 @@ run_ieugwasr_ard_compare <- function(
     if (!"SNP" %in% names(dat)) stop("annotate_chrpos(): 'SNP' column is missing.")
     snps <- unique(dat$SNP)
 
-    ann <- try(ieugwasr::reflookup(snps), silent = TRUE)
-    if (!inherits(ann, "try-error") && all(c("rsid","chr","pos") %in% names(ann))) {
+    ann <- try(ieugwasr::variants_rsid(snps), silent = TRUE)
+    if (!inherits(ann, "try-error") && all(c("name","chr","pos") %in% names(ann))) {
       ann <- ann |>
-        transmute(SNP = .data$rsid,
+        transmute(SNP = .data$name,
                   Chr = as.character(.data$chr),
                   Pos = as.numeric(.data$pos))
       return(left_join(dat, ann, by = "SNP"))


### PR DESCRIPTION
## Summary
- replace the deprecated `reflookup()` call in `annotate_chrpos()` with `ieugwasr::variants_rsid()`
- join on the tibble's `name`, `chr`, and `pos` columns when annotating SNP metadata

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1f2414a2c832caaa73cdb75b9ce31