### PR TITLE
Set force_refresh default to TRUE

### DIFF
--- a/R/run_phenome_mr.R
+++ b/R/run_phenome_mr.R
@@ -29,7 +29,7 @@
 #' @param confirm Character; whether to prompt before downloading required
 #'   resources when using Neale data. One of "ask", "yes", or "no".
 #' @param force_refresh Logical; if `TRUE`, re-download remote resources even if
-#'   they are already cached.
+#'   they are already cached. Defaults to `TRUE`.
 #'
 #' @return A list: MR_df, results_df, manhattan (ggplot), volcano (ggplot)
 #' @export
@@ -54,7 +54,7 @@ run_phenome_mr <- function(
     logfile = NULL,
     verbose = TRUE,
     confirm = 'ask',
-    force_refresh = FALSE
+    force_refresh = TRUE
 ) {
   # ---- validate args ----
   sex <- match.arg(sex)

--- a/man/run_phenome_mr.Rd
+++ b/man/run_phenome_mr.Rd
@@ -21,7 +21,7 @@ run_phenome_mr(
   logfile = NULL,
   verbose = TRUE,
   confirm = "ask",
-  force_refresh = FALSE
+  force_refresh = TRUE
 )
 }
 \arguments{
@@ -58,7 +58,7 @@ output directories and plot titles.}
 resources when using Neale data. One of "ask", "yes", or "no".}
 
 \item{force_refresh}{Logical; if \code{TRUE}, re-download remote resources even if
-they are already cached.}
+they are already cached. Defaults to \code{TRUE}.}
 }
 \value{
 A list: MR_df, results_df, manhattan (ggplot), volcano (ggplot)


### PR DESCRIPTION
## Summary
- default `force_refresh` to `TRUE` in `run_phenome_mr()` to always refresh cached resources unless overridden
- document the new default in both the roxygen comments and generated Rd file

## Testing
- `Rscript -e "devtools::document()"` *(fails: `Rscript` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d2bc0b1398832c9b52dca8a9c7a438