### PR TITLE
Handle groups with no ARD QC survivors

### DIFF
--- a/R/ard_compare.R
+++ b/R/ard_compare.R
@@ -313,8 +313,28 @@ ard_compare <- function(
 
   load_group_tables <- function(info) {
     base <- file.path(info$group_dir, "beta", "tables")
+    global_path <- file.path(base, "global.csv")
+    if (!file.exists(global_path)) {
+      if (isTRUE(verbose)) {
+        restore_compare_logging()
+        logger::log_warn(
+          "Beta summary tables were not found for sex={info$sex}, ancestry={info$ancestry} ({global_path})."
+        )
+      }
+      empty_scope <- list(
+        all_diseases = tibble::tibble(),
+        age_related_diseases = tibble::tibble()
+      )
+      return(list(
+        global = tibble::tibble(),
+        cause_level_1 = empty_scope,
+        cause_level_2 = empty_scope,
+        cause_level_3 = empty_scope
+      ))
+    }
+
     list(
-      global = ensure_tibble(read_table(file.path(base, "global.csv"), required = TRUE)),
+      global = ensure_tibble(read_table(global_path, required = FALSE)),
       cause_level_1 = list(
         all_diseases = ensure_tibble(read_table(file.path(base, "cause_level_1__all_diseases.csv"), required = FALSE)),
         age_related_diseases = ensure_tibble(read_table(file.path(base, "cause_level_1__age_related_diseases.csv"), required = FALSE))


### PR DESCRIPTION
## Summary
- add an early-return in `run_phenome_mr()` when no ARDs survive QC while still saving `results.rds`
- adjust `ard_compare()` to skip beta summary loading when the run produced no tables

## Testing
- not run (Rscript not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d34695a938832cb8b7929c26b6aff0