### PR TITLE
Add optional dot annotations to Manhattan plot

### DIFF
--- a/R/plots.R
+++ b/R/plots.R
@@ -38,6 +38,8 @@
 #' @param left_nuge numeric; horizontal leftward nudge of L2 labels in x data units (default 1)
 #' @param tree_down numeric; vertical nudge (down if negative) for L2 bracket + labels (default -0.08)
 #' @param label_down numeric; extra vertical nudge (down if negative) for labels only (default -0.02)
+#' @param dot_names logical; if `TRUE`, annotate significant points with their
+#'   outcome names (default `TRUE`).
 #' @export
 manhattan_plot <- function(results_df,
                            Multiple_testing_correction = c("BH","bonferroni"),
@@ -47,8 +49,10 @@ manhattan_plot <- function(results_df,
                            left_nuge = 1,
                            tree_down = -0.08,
                            label_down = -0.02,
+                           dot_names = TRUE,
                            exposure = NULL){
   Multiple_testing_correction <- match.arg(Multiple_testing_correction)
+  dot_names <- isTRUE(dot_names)
 
   if (is.null(results_df) || !nrow(results_df)) {
     if (verbose) logger::log_warn("Manhattan: input results_df is NULL or has 0 rows; returning placeholder plot.")
@@ -241,7 +245,7 @@ manhattan_plot <- function(results_df,
     df, .data$sig %in% TRUE, !is.na(.data$results_outcome),
     is.finite(.data$idx), is.finite(.data$logp)
   )
-  if (nrow(sig_df)) {
+  if (dot_names && nrow(sig_df)) {
     if (requireNamespace("ggrepel", quietly = TRUE)) {
       p <- p + ggrepel::geom_text_repel(
         data = sig_df,

--- a/R/run_phenome_mr.R
+++ b/R/run_phenome_mr.R
@@ -277,6 +277,19 @@ run_phenome_mr <- function(
   # manhattan_Bonf_all <- manhattan_plot(results_df,        Multiple_testing_correction = "bonferroni", exposure = exposure)
   # manhattan_Bonf_ARD <- manhattan_plot(results_ard_only,  Multiple_testing_correction = "bonferroni", exposure = exposure)
 
+  manhattan_with_names <- manhattan_plot(
+    results_df,
+    Multiple_testing_correction = cfg$mtc,
+    exposure = exposure,
+    dot_names = TRUE
+  )
+  manhattan_without_names <- manhattan_plot(
+    results_df,
+    Multiple_testing_correction = cfg$mtc,
+    exposure = exposure,
+    dot_names = FALSE
+  )
+
   manhattan_recolor_BH_all   <- manhattan_plot_recolor(results_df,       Multiple_testing_correction = "BH",         exposure = exposure)
   manhattan_recolor_BH_ARD   <- manhattan_plot_recolor(results_ard_only, Multiple_testing_correction = "BH",         exposure = exposure)
   manhattan_recolor_Bonf_all <- manhattan_plot_recolor(results_df,       Multiple_testing_correction = "bonferroni", exposure = exposure)
@@ -516,6 +529,10 @@ run_phenome_mr <- function(
 
   # ---- 7) Assemble hierarchical summary_plots list ----
   summary_plots <- list(
+    manhattan = list(
+      with_names = manhattan_with_names,
+      without_names = manhattan_without_names
+    ),
     # manhattan = list(
     #   BH = list(all = manhattan_BH_all, ARD_only = manhattan_BH_ARD),
     #   bonferroni = list(all = manhattan_Bonf_all, ARD_only = manhattan_Bonf_ARD)


### PR DESCRIPTION
## Summary
- add a `dot_names` argument to `manhattan_plot` so significant points can be optionally annotated
- call `manhattan_plot` twice in `run_phenome_mr` to produce labelled and unlabelled variants of the plot

## Testing
- `Rscript -e "devtools::test(filter = 'plot_wrappers')"` *(fails: command not found: Rscript)*

------
https://chatgpt.com/codex/tasks/task_e_68d3d7831e0c832cb74b5bc7318d0534