### PR TITLE
Add dot name toggle to volcano plot and wire into pipeline

### DIFF
--- a/R/plots.R
+++ b/R/plots.R
@@ -1333,6 +1333,7 @@ plot_enrichment_group_heatmap <- function(
 #' @param exposure Optional exposure label for the title.
 #' @param label_top_n How many most-significant points to label (default 25). Use Inf to label all significant.
 #' @param verbose If TRUE, log a few steps via {logger} if available.
+#' @param dot_names Logical; if TRUE, label significant points with their outcome names.
 #' @export
 volcano_plot <- function(results_df,
                          Multiple_testing_correction = c("BH","bonferroni"),
@@ -1340,7 +1341,8 @@ volcano_plot <- function(results_df,
                          alpha = 0.05,
                          exposure = NULL,
                          label_top_n = 25,
-                         verbose = TRUE) {
+                         verbose = TRUE,
+                         dot_names = TRUE) {
   Multiple_testing_correction <- match.arg(Multiple_testing_correction)
 
   if (is.null(results_df) || !nrow(results_df)) {
@@ -1456,7 +1458,7 @@ volcano_plot <- function(results_df,
 
   # Labels for most significant points (if results_outcome exists)
   lab_df <- tibble::tibble()
-  if ("results_outcome" %in% names(df)) {
+  if (isTRUE(dot_names) && "results_outcome" %in% names(df)) {
     lab_df <- dplyr::filter(df, .data$sig %in% TRUE & !is.na(.data$results_outcome))
     if (nrow(lab_df)) {
       # rank by significance (higher -log10 p first)

--- a/R/run_phenome_mr.R
+++ b/R/run_phenome_mr.R
@@ -283,6 +283,20 @@ run_phenome_mr <- function(
   manhattan_recolor_Bonf_ARD <- manhattan_plot_recolor(results_ard_only, Multiple_testing_correction = "bonferroni", exposure = exposure)
 
   # ---- 5B. VOLCANO ----
+  volcano_with_dot_names <- volcano_plot(
+    results_df,
+    Multiple_testing_correction = cfg$mtc,
+    exposure = exposure,
+    verbose = cfg$verbose,
+    dot_names = TRUE
+  )
+  volcano_without_dot_names <- volcano_plot(
+    results_df,
+    Multiple_testing_correction = cfg$mtc,
+    exposure = exposure,
+    verbose = cfg$verbose,
+    dot_names = FALSE
+  )
   # volcano_default <- volcano_plot(results_df, Multiple_testing_correction = cfg$mtc)
   volcano_recolor_BH_all   <- volcano_plot_recolor(results_df,       Multiple_testing_correction = "BH",         exposure = exposure)
   volcano_recolor_BH_ARD   <- volcano_plot_recolor(results_ard_only, Multiple_testing_correction = "BH",         exposure = exposure)
@@ -525,6 +539,10 @@ run_phenome_mr <- function(
       bonferroni = list(all = manhattan_recolor_Bonf_all, ARD_only = manhattan_recolor_Bonf_ARD)
     ),
     # volcano = list(default = volcano_default),
+    volcano = list(
+      with_dot_names = volcano_with_dot_names,
+      without_dot_names = volcano_without_dot_names
+    ),
     volcano_recolor = list(
       BH = list(all = volcano_recolor_BH_all, ARD_only = volcano_recolor_BH_ARD),
       bonferroni = list(all = volcano_recolor_Bonf_all, ARD_only = volcano_recolor_Bonf_ARD)


### PR DESCRIPTION
## Summary
- add a dot name toggle to `volcano_plot()` so labels can be suppressed when requested
- invoke `volcano_plot()` twice from `run_phenome_mr()` to capture labeled and unlabeled volcano plots
- store both versions in the summary plot hierarchy for downstream saving

## Testing
- Rscript -e "devtools::load_all()" *(fails: Rscript not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d3d7978d7c832c9a219c657fc7bfd4