### PR TITLE
Add dot_names toggle to recolor Manhattan plots

### DIFF
--- a/R/plots.R
+++ b/R/plots.R
@@ -305,8 +305,10 @@ manhattan_plot_recolor <- function(results_df,
                                    left_nuge = 1,
                                    tree_down = -0.08,
                                    label_down = -0.02,
+                                   dot_names = TRUE,
                                    exposure = NULL) {
   Multiple_testing_correction <- match.arg(Multiple_testing_correction)
+  dot_names <- isTRUE(dot_names)
 
   if (is.null(results_df) || !nrow(results_df)) {
     if (verbose) logger::log_warn("Manhattan (recolor): input results_df is NULL or has 0 rows; returning placeholder plot.")
@@ -461,28 +463,31 @@ manhattan_plot_recolor <- function(results_df,
       )
   }
 
-  if (!"results_outcome" %in% names(df)) {
-    stop("manhattan_plot_recolor(): 'results_outcome' column is required to label significant points.", call. = FALSE)
-  }
-  sig_df <- dplyr::filter(
-    df, .data$sig %in% TRUE, !is.na(.data$results_outcome),
-    is.finite(.data$idx), is.finite(.data$logp)
-  )
-  if (nrow(sig_df)) {
-    if (requireNamespace("ggrepel", quietly = TRUE)) {
-      p <- p + ggrepel::geom_text_repel(
-        data = sig_df,
-        ggplot2::aes(x = .data$idx, y = .data$logp, label = .data$results_outcome),
-        max.overlaps = Inf, box.padding = 0.25, point.padding = 0.15,
-        min.segment.length = 0, size = 2.7, seed = 123,
-        segment.size = 0.2
-      )
-    } else {
-      p <- p + ggplot2::geom_text(
-        data = sig_df,
-        ggplot2::aes(x = .data$idx, y = .data$logp, label = .data$results_outcome),
-        size = 2.7, vjust = -0.25, check_overlap = TRUE
-      )
+  sig_df <- df[FALSE, , drop = FALSE]
+  if (isTRUE(dot_names)) {
+    if (!"results_outcome" %in% names(df)) {
+      stop("manhattan_plot_recolor(): 'results_outcome' column is required to label significant points.", call. = FALSE)
+    }
+    sig_df <- dplyr::filter(
+      df, .data$sig %in% TRUE, !is.na(.data$results_outcome),
+      is.finite(.data$idx), is.finite(.data$logp)
+    )
+    if (nrow(sig_df)) {
+      if (requireNamespace("ggrepel", quietly = TRUE)) {
+        p <- p + ggrepel::geom_text_repel(
+          data = sig_df,
+          ggplot2::aes(x = .data$idx, y = .data$logp, label = .data$results_outcome),
+          max.overlaps = Inf, box.padding = 0.25, point.padding = 0.15,
+          min.segment.length = 0, size = 2.7, seed = 123,
+          segment.size = 0.2
+        )
+      } else {
+        p <- p + ggplot2::geom_text(
+          data = sig_df,
+          ggplot2::aes(x = .data$idx, y = .data$logp, label = .data$results_outcome),
+          size = 2.7, vjust = -0.25, check_overlap = TRUE
+        )
+      }
     }
   }
 

--- a/R/run_phenome_mr.R
+++ b/R/run_phenome_mr.R
@@ -290,10 +290,62 @@ run_phenome_mr <- function(
     dot_names = FALSE
   )
 
-  manhattan_recolor_BH_all   <- manhattan_plot_recolor(results_df,       Multiple_testing_correction = "BH",         exposure = exposure)
-  manhattan_recolor_BH_ARD   <- manhattan_plot_recolor(results_ard_only, Multiple_testing_correction = "BH",         exposure = exposure)
-  manhattan_recolor_Bonf_all <- manhattan_plot_recolor(results_df,       Multiple_testing_correction = "bonferroni", exposure = exposure)
-  manhattan_recolor_Bonf_ARD <- manhattan_plot_recolor(results_ard_only, Multiple_testing_correction = "bonferroni", exposure = exposure)
+  manhattan_recolor_BH_all <- list(
+    with_dot_names = manhattan_plot_recolor(
+      results_df,
+      Multiple_testing_correction = "BH",
+      exposure = exposure,
+      dot_names = TRUE
+    ),
+    without_dot_names = manhattan_plot_recolor(
+      results_df,
+      Multiple_testing_correction = "BH",
+      exposure = exposure,
+      dot_names = FALSE
+    )
+  )
+  manhattan_recolor_BH_ARD <- list(
+    with_dot_names = manhattan_plot_recolor(
+      results_ard_only,
+      Multiple_testing_correction = "BH",
+      exposure = exposure,
+      dot_names = TRUE
+    ),
+    without_dot_names = manhattan_plot_recolor(
+      results_ard_only,
+      Multiple_testing_correction = "BH",
+      exposure = exposure,
+      dot_names = FALSE
+    )
+  )
+  manhattan_recolor_Bonf_all <- list(
+    with_dot_names = manhattan_plot_recolor(
+      results_df,
+      Multiple_testing_correction = "bonferroni",
+      exposure = exposure,
+      dot_names = TRUE
+    ),
+    without_dot_names = manhattan_plot_recolor(
+      results_df,
+      Multiple_testing_correction = "bonferroni",
+      exposure = exposure,
+      dot_names = FALSE
+    )
+  )
+  manhattan_recolor_Bonf_ARD <- list(
+    with_dot_names = manhattan_plot_recolor(
+      results_ard_only,
+      Multiple_testing_correction = "bonferroni",
+      exposure = exposure,
+      dot_names = TRUE
+    ),
+    without_dot_names = manhattan_plot_recolor(
+      results_ard_only,
+      Multiple_testing_correction = "bonferroni",
+      exposure = exposure,
+      dot_names = FALSE
+    )
+  )
 
   # ---- 5B. VOLCANO ----
   volcano_with_dot_names <- volcano_plot(


### PR DESCRIPTION
## Summary
- add a `dot_names` flag to `manhattan_plot_recolor()` so recolor plots can omit labels when desired
- update `run_phenome_mr()` to render recolor Manhattan plots with and without dot labels in the same output hierarchy

## Testing
- Rscript -e "devtools::load_all()" *(fails: Rscript not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d400976fcc832cba289b36c2ff113f