### PR TITLE
Add dot label toggle to recolored volcano outputs

### DIFF
--- a/R/plots.R
+++ b/R/plots.R
@@ -1499,15 +1499,19 @@ volcano_plot <- function(results_df,
 #' and significant risk associations (β ≥ 0) in red.
 #'
 #' @inheritParams volcano_plot
+#' @param dot_names Logical; if `TRUE`, annotate significant outcomes on the
+#'   plot (default `TRUE`).
 #' @export
 volcano_plot_recolor <- function(results_df,
                                  Multiple_testing_correction = c("BH","bonferroni"),
                                  qc_pass_only = TRUE,
                                  alpha = 0.05,
                                  exposure = NULL,
+                                 dot_names = TRUE,
                                  label_top_n = 25,
                                  verbose = TRUE) {
   Multiple_testing_correction <- match.arg(Multiple_testing_correction)
+  dot_names <- isTRUE(dot_names)
 
   if (is.null(results_df) || !nrow(results_df)) {
     if (verbose && requireNamespace("logger", quietly = TRUE)) {
@@ -1622,7 +1626,7 @@ volcano_plot_recolor <- function(results_df,
   }
 
   lab_df <- tibble::tibble()
-  if ("results_outcome" %in% names(df)) {
+  if (isTRUE(dot_names) && "results_outcome" %in% names(df)) {
     lab_df <- dplyr::filter(df, .data$sig %in% TRUE & !is.na(.data$results_outcome))
     if (nrow(lab_df)) {
       lab_df <- lab_df[order(lab_df$logp, decreasing = TRUE), , drop = FALSE]

--- a/R/run_phenome_mr.R
+++ b/R/run_phenome_mr.R
@@ -316,6 +316,28 @@ run_phenome_mr <- function(
   volcano_recolor_Bonf_all <- volcano_plot_recolor(results_df,       Multiple_testing_correction = "bonferroni", exposure = exposure)
   volcano_recolor_Bonf_ARD <- volcano_plot_recolor(results_ard_only, Multiple_testing_correction = "bonferroni", exposure = exposure)
 
+  volcano_recolor_with_dot_names <- volcano_plot_recolor(
+    results_df,
+    Multiple_testing_correction = cfg$mtc,
+    exposure = exposure,
+    verbose = cfg$verbose,
+    dot_names = TRUE
+  )
+  volcano_recolor_without_dot_names <- volcano_plot_recolor(
+    results_df,
+    Multiple_testing_correction = cfg$mtc,
+    exposure = exposure,
+    verbose = cfg$verbose,
+    dot_names = FALSE
+  )
+
+  volcano_recolor_plot_list <- list(
+    BH = list(all = volcano_recolor_BH_all, ARD_only = volcano_recolor_BH_ARD),
+    bonferroni = list(all = volcano_recolor_Bonf_all, ARD_only = volcano_recolor_Bonf_ARD)
+  )
+  volcano_recolor_plot_list[[cfg$mtc]][["with_dot_names"]] <- volcano_recolor_with_dot_names
+  volcano_recolor_plot_list[[cfg$mtc]][["without_dot_names"]] <- volcano_recolor_without_dot_names
+
   # ---- 6) Signed enrichment analyses ----
   logger::log_info("6) Enrichment analyses…")
   enrich <- run_enrichment(
@@ -560,10 +582,7 @@ run_phenome_mr <- function(
       with_dot_names = volcano_with_dot_names,
       without_dot_names = volcano_without_dot_names
     ),
-    volcano_recolor = list(
-      BH = list(all = volcano_recolor_BH_all, ARD_only = volcano_recolor_BH_ARD),
-      bonferroni = list(all = volcano_recolor_Bonf_all, ARD_only = volcano_recolor_Bonf_ARD)
-    ),
+    volcano_recolor = volcano_recolor_plot_list,
     enrichment = list(
       global = list(
         violin_vertical = enrichment_global_violin_vertical,


### PR DESCRIPTION
## Summary
- add a `dot_names` flag to `volcano_plot_recolor()` so labels can be toggled on or off
- call the recolored volcano helper twice in `run_phenome_mr()` to generate labelled and unlabelled outputs and store them together

## Testing
- `Rscript -e "devtools::load_all()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d400c58398832c837e4d79aba6d2a1