### PR TITLE
Stop writing beta, manhattan, and volcano outputs

### DIFF
--- a/R/run_phenome_mr.R
+++ b/R/run_phenome_mr.R
@@ -831,7 +831,12 @@ run_phenome_mr <- function(
   logger::log_info("Beta mean cause-level plots generated: {n_beta_mean_plots}")
 
   # ---- 8) Save plots mirroring the list structure under cfg$plot_dir ----
-  save_plot_hierarchy(summary_plots, cfg$plot_dir)
+  # save_plot_hierarchy(summary_plots, cfg$plot_dir)
+  plots_to_save <- summary_plots
+  plots_to_save$beta <- NULL
+  plots_to_save$manhattan <- NULL
+  plots_to_save$volcano <- NULL
+  save_plot_hierarchy(plots_to_save, cfg$plot_dir)
 
   # ---- 8b) Export enrichment tables (CSV) + beta-contrast tables ----
   # write_enrichment_tables <- function(enrich, base_dir) {
@@ -924,7 +929,7 @@ run_phenome_mr <- function(
 
   # write_enrichment_tables(enrich, cfg$plot_dir)
   # write_beta_contrast_tables(beta_contrast_tables, cfg$plot_dir)
-  write_beta_tables(beta_tables, cfg$plot_dir)
+  # write_beta_tables(beta_tables, cfg$plot_dir)
 
   # ---- 9) Keep the originals around too (optional) ----
   # manhattan <- manhattan_BH_all

--- a/R/run_phenome_mr_plotting_only.R
+++ b/R/run_phenome_mr_plotting_only.R
@@ -695,7 +695,12 @@ run_phenome_mr_plotting_only <- function(
   }
 
   # Save all plots
-  save_plot_hierarchy(summary_plots, cfg$plot_dir)
+  # save_plot_hierarchy(summary_plots, cfg$plot_dir)
+  plots_to_save <- summary_plots
+  plots_to_save$beta <- NULL
+  plots_to_save$manhattan <- NULL
+  plots_to_save$volcano <- NULL
+  save_plot_hierarchy(plots_to_save, cfg$plot_dir)
 
   # ---- 8b) Export enrichment tables (CSV) + beta-contrast tables ----
   # write_enrichment_tables <- function(enrich, base_dir) {
@@ -788,7 +793,7 @@ run_phenome_mr_plotting_only <- function(
 
   # write_enrichment_tables(enrich, cfg$plot_dir)
   # write_beta_contrast_tables(beta_contrast_tables, cfg$plot_dir)
-  write_beta_tables(beta_tables, cfg$plot_dir)
+  # write_beta_tables(beta_tables, cfg$plot_dir)
 
   # ---- 9) Keep the originals around too (optional) ----
   # manhattan <- manhattan_BH_all


### PR DESCRIPTION
## Summary
- skip saving beta, manhattan, and volcano plot folders when exporting run_phenome_mr results
- stop writing beta tables so beta output directory stays empty while keeping recolor plots untouched

## Testing
- Rscript -e "devtools::test()" *(fails: Rscript not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d40c11eb68832ca232a88773e4e275