### PR TITLE
Capture compare output paths and write PhenoScanner summaries

### DIFF
--- a/R/ard_compare.R
+++ b/R/ard_compare.R
@@ -17,8 +17,8 @@
 #'   [run_phenome_mr()]. `exposure_snps` should contain the TwoSampleMR-style
 #'   instrument data for that group.
 #'
-#' @return Invisibly returns `NULL` after writing the combined compare outputs
-#'   to disk.
+#' @return Invisibly returns a list containing the compare output directory
+#'   (`compare_root`) and compare log file path (`compare_logfile`).
 #' @export
 ard_compare <- function(
     exposure,
@@ -790,5 +790,8 @@ ard_compare <- function(
     logger::log_warn("No enrichment data available for compare violin forest plot.")
   }
 
-  invisible(NULL)
+  invisible(list(
+    compare_root = compare_root,
+    compare_logfile = compare_logfile
+  ))
 }

--- a/man/ard_compare.Rd
+++ b/man/ard_compare.Rd
@@ -60,8 +60,8 @@ outputs for each group before re-running \code{\link[=run_phenome_mr]{run_phenom
 \code{FALSE} to reuse cached results.}
 }
 \value{
-Invisibly returns \code{NULL} after writing the combined compare outputs
-to disk.
+Invisibly returns a list containing the compare output directory
+\code{compare_root} and compare log file path \code{compare_logfile}.
 }
 \description{
 \code{ard_compare()} orchestrates repeated calls to \code{\link[=run_phenome_mr]{run_phenome_mr()}} for a

--- a/man/run_ieugwasr_ard_compare.Rd
+++ b/man/run_ieugwasr_ard_compare.Rd
@@ -48,7 +48,9 @@ exposure_units and phenoscanner_exclusions}
 \item{force_refresh}{If TRUE, force ard_compare() to refresh cached results}
 }
 \value{
-(invisible) list with names of processed exposure_groups
+(invisible) list containing the processed exposure group names, failure
+details, the combined PhenoScanner summary tibble, and the written
+PhenoScanner summary file paths.
 }
 \description{
 Build instruments from IEU GWAS, validate units, assemble groups, and run ard_compare()


### PR DESCRIPTION
## Summary
- have `ard_compare()` return the compare output directory and log file path for downstream consumers
- persist PhenoScanner pre-filter snapshots, track skipped queries, and write per-exposure summary CSVs alongside the compare logs
- document the updated return values and propagate summary metadata through `run_ieugwasr_ard_compare()`

## Testing
- `Rscript -e "devtools::document()"` *(fails: Rscript is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6f8d4a488832c95be9825765d5616