### PR TITLE
Add delay between successful PhenoScanner batches

### DIFF
--- a/R/ard_compare_grouped_ieugwasr.R
+++ b/R/ard_compare_grouped_ieugwasr.R
@@ -203,6 +203,8 @@ run_ieugwasr_ard_compare <- function(
           per_snp[[snp]] <- list(status = "failed", table = NULL, error = last_error)
           errors[[snp]] <- last_error
         }
+      } else if (i < length(chunks)) {
+        Sys.sleep(base_sleep)
       }
     }
 


### PR DESCRIPTION
## Summary
- add a base_sleep pause between successful PhenoScanner batch queries to avoid back-to-back requests

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d818d09c4c832cb5ee68c954120525