### PR TITLE
Fix ieugwasr phewas call to use variants argument

### DIFF
--- a/R/ard_compare_grouped_ieugwasr.R
+++ b/R/ard_compare_grouped_ieugwasr.R
@@ -289,7 +289,7 @@ run_ieugwasr_ard_compare <- function(
     }
 
     query_res <- tryCatch(
-      ieugwasr::phewas(rsid = snp_order, pval = phewas_pval),
+      ieugwasr::phewas(variants = snp_order, pval = phewas_pval),
       error = identity
     )
 


### PR DESCRIPTION
## Summary
- update the ieugwasr::phewas invocation to use the supported `variants` argument instead of the obsolete `rsid` parameter

## Testing
- not run (Rscript not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d8296d0e88832c823a7c4cb73e8c6c